### PR TITLE
Fix client initialization syntax in javascript examples

### DIFF
--- a/docs/apikeys.md
+++ b/docs/apikeys.md
@@ -73,7 +73,7 @@ The first step in using GDN is to establish a connection to a local region. When
 
     ``` js
     const jsc8 = require("jsc8");
-    const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "xxxx", fabricName= '_system'});
+    const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "xxxx", fabricName: '_system'});
 
     ```
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -24,7 +24,7 @@ client = C8Client(protocol='https', host='gdn.paas.macrometa.io', port=443,
 
 ```js
 const jsc8 = require("jsc8");
-const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "", fabricName= '_system'});
+const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "", fabricName: '_system'});
 await client.login("nemo@nautilus.com", "xxxxxx");
 ```
 
@@ -45,7 +45,7 @@ client = C8Client(protocol='https', host='gdn.paas.macrometa.io', port=443, toke
 
 ``` js
 const jsc8 = require("jsc8");
-const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "xxxxxx", fabricName= '_system'});
+const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "xxxxxx", fabricName: '_system'});
 ```
 
 ## API Keys
@@ -69,7 +69,7 @@ client = C8Client(protocol='https', host='gdn.paas.macrometa.io', port=443, apik
 
 ``` js
 const jsc8 = require("jsc8");
-const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "xxxxx", fabricName= '_system'});
+const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "xxxxx", fabricName: '_system'});
 ```
 
 !!! note

--- a/docs/cep/quickstart.md
+++ b/docs/cep/quickstart.md
@@ -103,9 +103,9 @@ The first step in using GDN is to establish a connection to a local region. When
     const jsc8 = require("jsc8");
 
     // Simple Way
-    const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
+    const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
     // ----- OR -----
-    const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
 
     // To use advanced options
     const client = new jsc8("https://gdn.paas.macrometa.io"); 
@@ -660,8 +660,8 @@ There are two ways in which you can use the python driver, both are shown below.
     console.log("--- Connecting to C8");
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance

--- a/docs/documents/quickstart.md
+++ b/docs/documents/quickstart.md
@@ -116,9 +116,9 @@ The first step in using GDN is to establish a connection to a region. When this 
     const jsc8 = require("jsc8");
 
     // Simple Way
-    const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
+    const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
     // ----- OR -----
-    const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
 
 
     // To use advanced options
@@ -149,8 +149,8 @@ To get details of fabric,
     const jsc8 = require("jsc8");
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -195,8 +195,8 @@ The below example shows the steps.
     const jsc8 = require("jsc8");
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -243,8 +243,8 @@ Let's add a `hash_index` called emails to our collection employees. Please refer
     const jsc8 = require("jsc8");
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -300,8 +300,8 @@ Let's insert documents to the employees collection as shown below.
     const jsc8 = require("jsc8");
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -363,8 +363,8 @@ The query `FOR employee IN employees RETURN employee` is equivalent to SQL's SEL
     const jsc8 = require("jsc8");
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -410,8 +410,8 @@ Example for real-time updates from a collection in fabric:
     const jsc8 = require("jsc8");
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -483,8 +483,8 @@ Create a geo-fabric with spot region capabilities. Then create a collection that
     const jsc8 = require("jsc8");
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -594,8 +594,8 @@ Query as API (aka RESTQL) enables developers to quickly convert saved C8QL queri
     const jsc8 = require('jsc8');
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance

--- a/docs/documents/tutorials/bulk-update-restql.md
+++ b/docs/documents/tutorials/bulk-update-restql.md
@@ -312,8 +312,8 @@ Let's assume your
     const jsc8 = require('jsc8');
 
     // Create a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     const client = new jsc8("https://gdn.paas.macrometa.io");
 
     //Variables

--- a/docs/documents/tutorials/using-realtime-updates.md
+++ b/docs/documents/tutorials/using-realtime-updates.md
@@ -142,8 +142,8 @@ Let's assume your
     const global_url = "https://gdn.paas.macrometa.io";
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: global_url, token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: global_url, apikey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: global_url, token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: global_url, apikey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance

--- a/docs/documents/tutorials/using-spotcollections.md
+++ b/docs/documents/tutorials/using-spotcollections.md
@@ -149,8 +149,8 @@ Let's assume your
     ];
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: global_url, token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: global_url, apikey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: global_url, token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: global_url, apikey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -201,8 +201,8 @@ Let's assume your
     async function readDataFromAllRegions(){
       for (let i = 0; i < region_urls.length; i++) { 
           // Crete a authenticated instance with Token / Apikey
-          // const regionclient = new jsc8({url: region_urls[i], token: "XXXX", fabricName= '_system'});
-          // const regionclient = new jsc8({url: region_urls[i], apikey: "XXXX", fabricName= '_system'});
+          // const regionclient = new jsc8({url: region_urls[i], token: "XXXX", fabricName: '_system'});
+          // const regionclient = new jsc8({url: region_urls[i], apikey: "XXXX", fabricName: '_system'});
           // await console.log("Authentication done!!...");
 
           // Or use Email & Password to Authenticate client instance

--- a/docs/documents/tutorials/working-with-documents.md
+++ b/docs/documents/tutorials/working-with-documents.md
@@ -164,8 +164,8 @@ Let's assume your
     ];
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: global_url, token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: global_url, apikey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: global_url, token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: global_url, apikey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -233,8 +233,8 @@ Let's assume your
       console.log("\n 6. CHECK_IF_IP_ALLOWED_GLOBALLY");
       for (let i = 0; i < region_urls.length; i++) { 
           // Crete a authenticated instance with Token / Apikey
-          // const regionclient = new jsc8({url: region_urls[i], token: "XXXX", fabricName= '_system'});
-          // const regionclient = new jsc8({url: region_urls[i], apikey: "XXXX", fabricName= '_system'});
+          // const regionclient = new jsc8({url: region_urls[i], token: "XXXX", fabricName: '_system'});
+          // const regionclient = new jsc8({url: region_urls[i], apikey: "XXXX", fabricName: '_system'});
           // await console.log("Authentication done!!...");
 
           // Or use Email & Password to Authenticate client instance

--- a/docs/geospatial/tutorial.md
+++ b/docs/geospatial/tutorial.md
@@ -205,8 +205,8 @@ Let's assume your
     const global_url = "https://gdn.paas.macrometa.io";
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: global_url, token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: global_url, apikey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: global_url, token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: global_url, apikey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance

--- a/docs/graphs/quickstart.md
+++ b/docs/graphs/quickstart.md
@@ -138,9 +138,9 @@ The first step in using GDN is to establish a connection to a local region. When
     const jsc8 = require("jsc8");
 
     // Simple Way
-    const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
+    const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
     // ----- OR -----
-    const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
 
 
     // To use advanced options
@@ -168,8 +168,8 @@ To get details of fabric,
     const jsc8 = require("jsc8");
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -213,8 +213,8 @@ The below example shows the steps.
     const jsc8 = require("jsc8");
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -270,8 +270,8 @@ An **edge collection** contains edge documents and shares its namespace with all
     const jsc8 = require("jsc8");
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -326,8 +326,8 @@ Let's insert documents to the employees collection as shown below.
     const jsc8 = require("jsc8");
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -387,8 +387,8 @@ A graph consists of vertices and edges. Vertices are stored as documents in vert
     const jsc8 = require("jsc8");
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -621,8 +621,8 @@ A graph consists of `vertices` and `edges`. Vertices are stored as documents in 
     const global_url = "https://gdn.paas.macrometa.io";
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -900,8 +900,8 @@ A graph consists of `vertices` and `edges`. Vertices are stored as documents in 
     const jsc8 = require("jsc8");
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance

--- a/docs/keyvalue/quickstart.md
+++ b/docs/keyvalue/quickstart.md
@@ -95,9 +95,9 @@ The first step in using GDN is to establish a connection to a local region. When
     const jsc8 = require("jsc8");
 
     // Simple Way
-    const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "", fabricName= '_system'});
+    const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "", fabricName: '_system'});
     // ----- OR -----
-    const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "<your-api-key>", fabricName= '_system'});
+    const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "<your-api-key>", fabricName: '_system'});
 
     // To use advanced options
     const client = new jsc8("https://gdn.paas.macrometa.io"); 
@@ -497,8 +497,8 @@ Complete code example written using above code snippets can be found below.
     const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: key});
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance

--- a/docs/keyvalue/tutorials/bulk-update-restql.md
+++ b/docs/keyvalue/tutorials/bulk-update-restql.md
@@ -312,8 +312,8 @@ Let's assume your
     const jsc8 = require('jsc8');
 
     // Create a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     const client = new jsc8("https://gdn.paas.macrometa.io");
 
     //Variables

--- a/docs/restql/tutorial.md
+++ b/docs/restql/tutorial.md
@@ -179,8 +179,8 @@ Let's assume your
     const global_url = "https://gdn.paas.macrometa.io";
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: global_url, token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: global_url, apikey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: global_url, token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: global_url, apikey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance

--- a/docs/search/quickstart.md
+++ b/docs/search/quickstart.md
@@ -99,9 +99,9 @@ The first step in using GDN is to establish a connection to a local region. When
     const jsc8 = require("jsc8");
 
     // Simple Way
-    const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "", fabricName= '_system'});
+    const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "", fabricName: '_system'});
     // ----- OR -----
-    const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "<your-api-key>", fabricName= '_system'});
+    const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "<your-api-key>", fabricName: '_system'});
 
     // To use advanced options
     const client = new jsc8("https://gdn.paas.macrometa.io"); 

--- a/docs/streams/quickstart.md
+++ b/docs/streams/quickstart.md
@@ -112,9 +112,9 @@ The first step in using GDN is to establish a connection to a local region. When
     ``` js
     const jsc8 = require("jsc8");
     // Simple Way
-    const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
+    const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
     // ----- OR -----
-    const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
 
 
     // To use advanced options
@@ -142,8 +142,8 @@ To get details of fabric,
     const jsc8 = require("jsc8");
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -195,8 +195,8 @@ The streams in GDN can be either a local stream or could be a geo-replicated str
     const jsc8 = require("jsc8");
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -268,8 +268,8 @@ Example to publish documents to a stream. The stream can be either a local strea
     const jsc8 = require("jsc8")
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance
@@ -354,8 +354,8 @@ Example to subscribe documents from a stream. The stream can be either a local s
     const jsc8 = require('jsc8');
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: "https://gdn.paas.macrometa.io", apiKey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance

--- a/docs/streams/tutorials/pub-sub-streams.md
+++ b/docs/streams/tutorials/pub-sub-streams.md
@@ -150,8 +150,8 @@ Let's assume your
     const global_url = "https://gdn.paas.macrometa.io";
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: global_url, token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: global_url, apikey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: global_url, token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: global_url, apikey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance

--- a/docs/streams/tutorials/using-realtime-updates.md
+++ b/docs/streams/tutorials/using-realtime-updates.md
@@ -139,8 +139,8 @@ Let's assume your
     const global_url = "https://gdn.paas.macrometa.io";
 
     // Crete a authenticated instance with Token / Apikey
-    // const client = new jsc8({url: global_url, token: "XXXX", fabricName= '_system'});
-    // const client = new jsc8({url: global_url, apikey: "XXXX", fabricName= '_system'});
+    // const client = new jsc8({url: global_url, token: "XXXX", fabricName: '_system'});
+    // const client = new jsc8({url: global_url, apikey: "XXXX", fabricName: '_system'});
     // await console.log("Authentication done!!...");
 
     // Or use Email & Password to Authenticate client instance


### PR DESCRIPTION
Looks like maybe a small copy+paste error that come over from the python examples :)