### PR TITLE
Updating GDN URL link

### DIFF
--- a/docs/documents/tutorials/using_rest_api.md
+++ b/docs/documents/tutorials/using_rest_api.md
@@ -52,7 +52,7 @@ Here is an example of a valid document:
 
     # Constants
 
-    FEDERATION = "api-gdn.macrometa.io"
+    FEDERATION = "api-gdn.paas.macrometa.io"
     FED_URL = "https://{}".format(FEDERATION)
     EMAIL = "nemo@nautilus.com"
     PASSWORD = "xxxxxx"
@@ -230,7 +230,7 @@ Here is an example of a valid document:
     }
     const EMAIL = "nemo@nautilus.com";
     const PASSWORD = "xxxxxx";
-    const FEDERATION_URL = "https://api-gdn.prod.macrometa.io";
+    const FEDERATION_URL = "https://api-gdn.paas.macrometa.io";
 
     const COLLECTION_NAME = "api_tutorial_documents";
 
@@ -330,7 +330,7 @@ CRUD Operations can also be done using C8QL
     ``` py
     #Using C8QL
 
-    FEDERATION = "api-gdn.macrometa.io"
+    FEDERATION = "api-gdn.paas.macrometa.io"
     FED_URL = "https://{}".format(FEDERATION)
 
     # Create a HTTPS Session
@@ -398,7 +398,7 @@ Macrometa GDN is a geo-distributed realtime data service with turnkey global dis
 
     # Constants
 
-    FEDERATION = "api-gdn.macrometa.io"
+    FEDERATION = "api-gdn.paas.macrometa.io"
     FED_URL = "https://{}".format(FEDERATION)
     EMAIL = "nemo@nautilus.com"
     PASSWORD = "xxxxxx"
@@ -609,7 +609,7 @@ Macrometa GDN is a geo-distributed realtime data service with turnkey global dis
 
     const EMAIL = "nemo@nautilus.com";
     const PASSWORD = "xxxxxx";
-    const FEDERATION_URL = "https://api-gdn.prod.macrometa.io";
+    const FEDERATION_URL = "https://api-gdn.paas.macrometa.io";
 
     const QUERY_NAME = "api_query_tutorial";
     const QUERY_PARAMS = { "@collection": "api_query_tutorial" };


### PR DESCRIPTION
All the links in PY/JS code are incorrect, added (paas.), issue reported in #525 ticket.
Also, link in the side menu Collections - Documents - Tutorials - Using Rest API leads to the Search - Tutorials - Using Rest API (there is not serach tutorial page for rest API) + if you write "collection API" in the search field and choose Using Rest APis, it will lead you to the page (https://macrometa.com/docs/search/tutorials/using-rest-api/)90% same as above one but nowhere to be found via links