### PR TITLE
Add note to Stream workers page

### DIFF
--- a/docs/cep/quickstart.md
+++ b/docs/cep/quickstart.md
@@ -1,5 +1,8 @@
 # Quick Start with Stream Processing
 
+!!! note
+     Currently, Strem workers are available only to Enterprise clients.
+     
 ## Overview
 
 Macrometa GDN allows you to integrate streaming data and take action based on streaming data. Typically the stream processing use cases involve collecting, analyzing and, integrate or acting on data generated during business activities by various sources i.e.,


### PR DESCRIPTION
adding a note that states that Streams Workers are currently available only for enterprise users.