### PR TITLE
Delete link to private github repo

### DIFF
--- a/docs/demos/streamlit-oxford.md
+++ b/docs/demos/streamlit-oxford.md
@@ -22,7 +22,3 @@ $ nohup streamlit run --server.port 4005 gdn_app.py &
 ```
 
 The console will display the localhost URL & Port number to connect.
-
-## Further info
-
-To learn more about the demo. Please visit our [github repository](https://github.com/Macrometacorp/tutorial-streamlit-oxford/blob/main/GlobalCities/).


### PR DESCRIPTION
Github repo is private, link shows up as 404 for most customers.  @elof 