### PR TITLE
Added GeoSpatial to doc structure

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -210,6 +210,7 @@ nav:
       - Patterns & Trends: cep/reference/patterns-n-trends.md
       - Data Pipelines: cep/reference/data-pipelining.md
       - Error Handling: cep/reference/error-handling.md
+      - GeoSpatial: cep/reference/geospatial.md
       - Query Guide: cep/reference/query-guide.md
       - Functions: cep/reference/functions.md
       - Extensions:


### PR DESCRIPTION
Hey @elof - in my last pull request I mistakenly reverted the change added GeoSpatial to the doc structure.  Opening this one to fix that error 🙂 