### PR TITLE
Fix essentials link

### DIFF
--- a/docs/keyvalue/quickstart.md
+++ b/docs/keyvalue/quickstart.md
@@ -2,7 +2,7 @@
 
 Macrometa GDN is a geodistributed real-time coordination-free materialized views engine that supports multiple data models. You can use GDN as a geo-replicated real-time key-value datastore or database. 
 
-If you are new to Macrometa GDN, start by reading the [essentials](../../essentials.md) of Macrometa GDN.
+If you are new to Macrometa GDN, start by reading the [essentials](../../essentials) of Macrometa GDN.
 
 Each document stored in a *collection* (or table) contains a primary key `_key`. The rest of the document is considered a value. The collection behaves like a simple *key-value* (KV) store if it has no secondary indexes.
 


### PR DESCRIPTION
Remove ".md" from Essentials link to properly link to the page.