### PR TITLE
Correction to two code examples in CEP Quickstart

### DIFF
--- a/docs/cep/quickstart.md
+++ b/docs/cep/quickstart.md
@@ -154,7 +154,7 @@ Validate the stream application for syntax errors before saving.
 	"""
 
     print("--- Validating Stream Application Definition")
-    print(client.validate_stream_app(data=script_app))
+    print(client.validate_stream_app(data=stream_app_definition))
     ```
 
 === "Javascript"
@@ -211,7 +211,7 @@ By default, the stream application saves in the local region. Optionally, you ca
 
     ``` py
     print("--- Creating Stream Application")
-    print(client.create_stream_app(data=script_app))
+    print(client.create_stream_app(data=stream_app_definition))
     ```
 
 === "Javascript"


### PR DESCRIPTION
I missed an instance of the variable I replaced in my previous pull request. This should address the issue with the validate stream app function call.