### PR TITLE
Added support for baseUrl in dev + prod with redirect

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,17 +9,19 @@ const {
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
+const isDev = process.env.NODE_ENV === 'development';
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Macrometa',
   tagline: 'Macrometa GDN Documentation',
   url: 'https://macrometa.com',
-  baseUrl: '/',
+  baseUrl: isDev ? '/' : '/new-docs/',
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
-  organizationName: 'Macrometacorp', // Usually your GitHub org/user name.
-  projectName: 'documentation', // Usually your repo name.
+  organizationName: 'macrometacorp', // Usually your GitHub org/user name.
+  projectName: 'new-docs', // Usually your repo name.
   clientModules: [require.resolve('./src/css/tailwind.css')],
   themes: ['@docusaurus/theme-live-codeblock'],
 

--- a/src/pages/api.js
+++ b/src/pages/api.js
@@ -2,8 +2,11 @@ import React from 'react';
 import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import BrowserOnly from '@docusaurus/BrowserOnly';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 export default function APIPage() {
+  const { siteConfig } = useDocusaurusContext();
+
   return (
     <Layout>
       <Head>
@@ -33,7 +36,7 @@ export default function APIPage() {
             <>
               {/* https://api-gdn.paas.macrometa.io/_admin/api/swagger.json */}
               <API
-                apiDescriptionUrl="/swagger.json"
+                apiDescriptionUrl={`${siteConfig.baseUrl}swagger/spec.json`}
                 router="hash"
                 basePath="/"
                 layout="sidebar"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import { Redirect } from '@docusaurus/router';
 import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
 export default function Homepage() {
+  const { siteConfig } = useDocusaurusContext();
+
   return (
     <>
       <Head>
@@ -18,7 +21,7 @@ export default function Homepage() {
         />
         <link rel="canonical" href="https://macrometa.com/docs" />
       </Head>
-      <Redirect to="/docs/quickstart" />
+      <Redirect to={`${siteConfig.baseUrl}docs/quickstart`} />
     </>
   );
 }

--- a/static/swagger/spec.json
+++ b/static/swagger/spec.json
@@ -1233,7 +1233,8 @@
           },
           "tenant": {
             "description": "The name of the tenant for whose user we want the auth token.\n\n",
-            "type": "string"
+            "type": "string",
+            "default": "root"
           },
           "username": {
             "description": "The name of the user for whom we want the auth token.\n\n",
@@ -1241,6 +1242,7 @@
           }
         },
         "required": [
+          "email",
           "password"
         ],
         "type": "object"
@@ -8335,6 +8337,14 @@
       "/_open/auth": {
         "post": {
           "description": "\n\nObtain a JWT Authentication for a user. After obtaining the token, REST API\ncalls may be invoked by passing the obtained token in the REST header.\nEither email or both tenant and username must be specified.\nAdd the following to your header when you make REST calls:\n*\"Authorization: bearer TOKEN\"*\n\n\nA JSON object with these properties is required:\n\n  - **username**: The name of the user for whom we want the auth token.\n  - **password**: The user password as a string. \n  - **email**: The email of the user for whom we want the auth token.\n  - **tenant**: The name of the tenant for whose user we want the auth token.\n\n",
+          
+          "consumes": [
+            "application/json"
+          ],
+          "produces": [
+            "application/json"
+          ],
+
           "parameters": [
             {
               "in": "body",


### PR DESCRIPTION
- The `baseUrl` is now set to `/new-docs/` when a `NODE_ENV=production` (default for the `build` command). The `baseUrl` defaults to `/` when in development mode for local development.
- Redirect on load now uses the `baseUrl` value using the docusuaurus context `siteConfig` object.
- Move the Swagger spec under `/static/swagger/` and renamed the file to `spec.json` for now. Adding the swagger file to a directory in `static` is the right thing to do according to the docs.