### PR TITLE
CSS cleanup and misc. fixes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -60,7 +60,6 @@ const config = {
         searchParameters: {},
       },
       navbar: {
-
         logo: {
           alt: 'Macrometa Logo',
           src: 'img/logo.svg',

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -111,7 +111,6 @@
 }
 
 /* Docusaurus styles */
-
 .docusaurus-highlight-code-line {
   background-color: #353535;
   display: block;
@@ -119,52 +118,31 @@
   padding: 0 var(--ifm-pre-padding);
 }
 
-.menu {
-  @apply overflow-y-auto !p-0;
-}
-
-.menu > .menu__list > .menu__list-item:first-child {
-  margin-top: 16px;
-}
-
-.menu {
-  @apply !font-normal;
-}
-
 /* Sidebar nav header  */
-.menu > .menu__list > .menu__list-item > .menu__link {
-  @apply mb-1 text-xs font-light tracking-normal text-text-100;
-}
 
 .menu > .menu__list > .menu__list-item {
-  @apply mb-4 text-sm;
+  @apply text-sm font-normal;
 }
 
-div[class^='sidebar_']
-  .menu__link.menu__link--active:not(.menu__link--sublist) {
+div[class^='sidebar_'] .menu__link.menu__link--active:not(.menu__link--sublist) {
   border-radius: 4px 0 0 4px;
   border-right: 2px solid var(--ifm-color-primary);
   color: var(--ifm-color-primary);
   background: rgba(33, 96, 253, 0.16);
 }
 
-/* Optional style for only one link which acts as nav section header */
-
-.menu > .menu__list > .menu__list-item > .menu__link:only-child {
-  @apply text-base normal-case tracking-normal;
-  color: var(--ifm-menu-color);
-}
-
-.menu > .menu__list > .menu__list-item > .menu__link {
-  @apply mt-3 text-sm font-normal text-text-100;
-}
-
-.menu > .menu__list > .menu__list-item > .menu__link--active:only-child {
-  color: var(--ifm-color-primary);
-}
-
 .menu__link--sublist::after {
   background: var(--ifm-menu-link-sublist-icon) 50% / 1.25rem 1.25rem;
+}
+
+/* Optional style for only one link which acts as nav section header */
+
+.navbar__item {
+  @apply font-normal;
+}
+
+.navbar__item svg {
+  display: none;
 }
 
 .navbar__logo {
@@ -189,74 +167,9 @@ hr {
   @apply border border-border;
 }
 
-.dropdown__menu {
-  left: initial;
-  right: 0;
-  @apply shadow-lg;
-}
-
-.dropdown .navbar__link {
-  @apply text-sm;
-}
-
-.navbar__item {
-  display: block;
-}
-
-.dropdown {
-  min-width: 72px;
-  @apply !flex h-12 items-center justify-end rounded-md;
-}
-
-.dropdown__menu {
-  padding-left: 0;
-  padding-right: 0;
-  @apply bg-background-100;
-}
-
-.dropdown__link {
-  border-radius: 0;
-  margin: 0;
-  @apply flex items-center justify-between px-3 py-2 hover:bg-background-200;
-}
-
-.dropdown__link--active {
-  @apply bg-background-100;
-}
-
-.dropdown__link--active::after {
-  content: '';
-  width: 6px;
-  height: 6px;
-  @apply block rounded-full bg-primary;
-}
-
-.navbar-sidebar__back {
-  @apply text-sm font-medium;
-}
-
+/* DocSearch */
 .DocSearch.DocSearch-Button {
   @apply rounded-full md:rounded-[4px];
-}
-
-/* Fixes hidden dropdown in mobile sidebar */
-.footer__link-separator,
-.navbar__item {
-  display: flex !important;
-}
-
-.menu > .menu__list > .menu__list-item > .menu__link:only-child {
-  font-size: 14px;
-  margin: 0;
-}
-
-.menu > .menu__list > .menu__list-item {
-  margin-bottom: 0rem;
-  line-height: 1rem;
-}
-
-.theme-doc-version-badge {
-  @apply border-border bg-background-100 text-text-100;
 }
 
 .DocSearch-Button-Key {
@@ -264,9 +177,24 @@ hr {
   --docsearch-muted-color: rgba(0, 0, 0, 0.87) !important;
 }
 
+.DocSearch-Hit-title {
+  @apply text-sm font-normal;
+}
+
 html[data-theme='dark'] .DocSearch-Button-Key {
   --docsearch-muted-color: rgba(255, 255, 255, 0.87) !important;
 }
+
+/* Menu fix */
+
+.menu {
+  @apply overflow-y-auto !p-0;
+}
+
+.menu > .menu__list > .menu__list-item:first-child {
+  margin-top: 16px;
+}
+
 
 /* Styles for @stoplight/elements */
 
@@ -307,6 +235,7 @@ html[data-theme='dark'] .DocSearch-Button-Key {
 
 .sl-elements-api > .sl-px-24 {
   @apply pl-8 pr-4;
+  background-color: var(--docs-color-background);
 }
 
 .sl-text-base {
@@ -386,7 +315,7 @@ html[data-theme='dark'] .DocSearch-Button-Key {
 }
 
 .sl-elements-api > div:first-child {
-  @apply !min-w-[240px] !max-w-[300px] !pl-0;
+  min-width: var(--doc-sidebar-width);
 }
 
 .sl-elements-api > div:last-child > div {


### PR DESCRIPTION
@elof There was CSS overriding the default top nav functionality. I cleaned that up and a few other styles throughout. In a mobile viewport, the nav items end up in the hamburger slide out but they're nested a level back (default behavior and the only way around this is a custom theme). 

<img width="303" alt="Screen Shot 2022-03-31 at 8 21 01 PM" src="https://user-images.githubusercontent.com/1328388/161182006-56efa84c-ab78-4311-9e69-c88bf7989c7c.png">

<img width="301" alt="Screen Shot 2022-03-31 at 8 20 48 PM" src="https://user-images.githubusercontent.com/1328388/161182023-9640dcf8-c11e-4073-b769-289c7ec2dbdd.png">

<img width="304" alt="Screen Shot 2022-03-31 at 8 20 39 PM" src="https://user-images.githubusercontent.com/1328388/161182035-00b884a6-5612-4552-aa01-97c95ddf5f86.png">


