### PR TITLE
Update working-with-indexes.md

### DIFF
--- a/docs/collections/documents/indexing/working-with-indexes.md
+++ b/docs/collections/documents/indexing/working-with-indexes.md
@@ -1016,7 +1016,7 @@ Building an index is always a write heavy operation (internally), it is always a
 
 ## Troubleshooting
 
-When in doubt about whether and which indexes will be used for executing a given C8QL query, click the `Execution Plan` button in the web interface in the `Queries`view.
+When in doubt about whether and which indexes will be used for executing a given C8QL query, click **Execution Plan** in the web interface in the Queries view.
 
 If any of the explain methods shows that a query is not using indexes, the following steps may help:
 

--- a/docs/collections/documents/indexing/working-with-indexes.md
+++ b/docs/collections/documents/indexing/working-with-indexes.md
@@ -888,7 +888,7 @@ FOR v, e, p IN 1..1 OUTBOUND "V/1" edges
 will be considerably faster in case there are many edges originating in vertex `"V/1"` but only few with a recent time stamp.
 
 
-## Collection index operations
+## Collection Index Operations
 
 **Listing all indexes of a collection:**
 

--- a/docs/collections/documents/indexing/working-with-indexes.md
+++ b/docs/collections/documents/indexing/working-with-indexes.md
@@ -991,7 +991,7 @@ curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/skip
  -H 'Authorization: bearer <token>'                                                                            \
  -d '{ "type": "skiplist", "fields": [ "abc", "def" ], "sparse": true, "inBackground": true }'
 
-// also supported on fulltext and Geo indexes
+// Also supported on fulltext and Geo indexes
 curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/fulltext?collection=collectioName' \
  -H 'Authorization: bearer <token>'                                                                            \
  -d '{ "type": "fulltext", "fields": [ "text" ], "minLength": 4, "inBackground": true }'

--- a/docs/collections/documents/indexing/working-with-indexes.md
+++ b/docs/collections/documents/indexing/working-with-indexes.md
@@ -236,7 +236,7 @@ Creating a new document or updating a document will fail if the uniqueness is vi
 Ensures that a unique persistent index exists
 
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/persistent?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/persistent?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                              \    
  -d '{ "fields": [ "type" : "persistent", "fields::["field1", ..., "fieldn" ], "unique": true}'
 ```
@@ -247,7 +247,7 @@ All documents in the collection must differ in terms of the indexed attributes. 
 
 To create a sparse unique index, set the *sparse* attribute to `true`:
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/persistent?collection=collectioName'  \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/persistent?collection=collectionName'  \
  -H 'Authorization: bearer <token>'                                                                               \
  -d '{ "fields": [ "type" : "persistent", "fields: ["field1", ..., "fieldn" ], "unique": true, "sparse" : true}'
 ```
@@ -261,7 +261,7 @@ In case that the index was successfully created, an object with the index detail
 
 To ensure that a non-unique persistent index exists
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/persistent?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/persistent?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                              \
  -d '{ "fields": [ "type" : "persistent", "fields::["field1", ..., "fieldn" ]}'
 ```
@@ -337,7 +337,7 @@ One use case supported by TTL indexes is to remove documents at a fixed duration
 Let's assume the index attribute is set to "creationDate", and the `expireAfter` attribute of the index was set to 600 seconds (10 minutes).
 
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/ttl?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/ttl?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                       \
  -d '{ "fields": [ "type" : "ttl", ."fields": ["creationDate"],  "expireAfter": 600}'
 ```
@@ -371,7 +371,7 @@ Another use case is to specify a per-document expiration/removal point in time, 
 Let's assume the index attribute is set to "expireDate", and the `expireAfter` attribute of the index was set to 0 seconds (immediately when wall clock time reaches the value specified in `expireDate`).
 
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/ttl?collection=collectioName' \ 
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/ttl?collection=collectionName' \ 
  -H 'Authorization: bearer <token>'                                                                       \
  -d '{ "fields": [ "type" : "ttl", ."fields": ["expireDate"],  "expireAfter": 0}'
 ```
@@ -438,7 +438,7 @@ There are limited number of background threads for performing the removal of exp
 Ensures that a TTL index exists:
 
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/ttl?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/ttl?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                       \
  -d '{ "fields": [ "type" : "ttl", ."fields": ["field"],  "expireAfter": 600}'
 ```
@@ -478,7 +478,7 @@ If the index attribute is neither a string, an object or an array, its contents 
 
 Ensures that a fulltext index exists:
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/fulltext?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/fulltext?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                            \
  -d '{ "fields": [ "type" : "fulltext", ."fields": ["field"],  "minLength": <minLength> }'
 ```
@@ -516,7 +516,7 @@ This index assumes coordinates with the latitude between -90 and 90 degrees and 
 To create an index in GeoJSON mode execute:
 
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?collection=collectioName'  \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?collection=collectionName'  \
  -H 'Authorization: bearer <token>'                                                                        \
  -d '{ "fields": [ "type" : "geo", ."fields": ["geometry"],  "geoJson": true }'
 ```
@@ -536,7 +536,7 @@ This index mode exclusively supports indexing on coordinate arrays. Values that 
 To create a geo-spatial index on all documents using *latitude* and *longitude* as separate attribute paths, two paths need to be specified in the *fields* array:
 
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                       \  
  -d '{ "fields": [ "type" : "geo", ."fields": ["latitude", "longitude"] }'
 ```
@@ -546,7 +546,7 @@ The first field is always defined to be the _latitude_ and the second is the _lo
 Alternatively you can specify only one field:
 
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                       \
  -d '{ "fields": [ "type" : "geo", ."fields": ["location"],  "geoJson": false }'
 ```
@@ -816,7 +816,7 @@ Example with two polygons, the second one with a hole:
 ensures that a geo index exists
 
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                       \
  -d '{ "fields": [ "type" : "geo", ."fields": ["location"]}'
 ```
@@ -831,7 +831,7 @@ In case that the index was successfully created, an object with the index detail
 To create a geo index on an array attribute that contains longitude first, set the *geoJson* attribute to `true`. This corresponds to the format described in [RFC 7946 Position](https://tools.ietf.org/html/rfc7946#section-3.1.1){:target="_blank"}
 
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                       \
  -d '{ "fields": [ "type" : "geo", ."fields": ["location"],  "geoJson": true }'
 ```
@@ -839,7 +839,7 @@ curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?
 To create a geo-spatial index on all documents using *latitude* and *longitude* as separate attribute paths, two paths need to be specified in the *fields* array:
 
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?collection=collectioName'  \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?collection=collectionName'  \
  -H 'Authorization: bearer <token>'                                                                        \
  -d '{ "fields": [ "type" : "geo", ."fields": ["latitude", "longitude" ] }'
 ```
@@ -849,7 +849,7 @@ In case that the index was successfully created, an object with the index detail
 
 ensures that a geo index exists
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                       \
  -d '{ "fields": [ "type" : "geo", ."fields": [ "location" ] }'
 ```
@@ -871,7 +871,7 @@ One can create sorted indexes (type "skiplist" and "persistent") that index the 
 For example, to create a vertex centric index of the above type, you would simply do
 
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/skiplist?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/skiplist?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                            \
  -d '{ "fields": [ "type" : "skiplist", ."fields": [ "_from", "timestamp" ] }'
 ```
@@ -906,7 +906,7 @@ Indexes should be created using the general method `ensureIndex`.
 
 ensures that an index exists
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/<indexType>?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/<indexType>?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                            \
  -d '{ <Index description> }'
 ```
@@ -936,11 +936,11 @@ Calling this method returns an index object. Whether or not the index object exi
 
 **Examples**
 ```cURL
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/hash?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/hash?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                        \
  -d '{ "type": "hash", "fields": [ "a" ], "sparse": true }'
  
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/hash?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/hash?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                        \
  -d '{ "type": "hash", "fields": [ "a", "b"], "unique": true }'
 ```
@@ -973,30 +973,30 @@ To create an index in the background, just specify `inBackground: true`, like in
 
 ```cURL
 // create the hash index in the background
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/hash?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/hash?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                        \
  -d '{ "type": "hash", "fields": [ "value" ], "unique": false, "inBackground": true }'
  
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/hash?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/hash?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                        \
  -d '{ "type": "hash", "fields": [ "email" ], "unique": true, "inBackground": true }'
  
  
 // skiplist indexes work also of course
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/skiplist?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/skiplist?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                            \
  -d '{ "type": "skiplist", "fields": [ "abc", "def" ], "unique": true, "inBackground": true }'
 
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/skiplist?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/skiplist?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                            \
  -d '{ "type": "skiplist", "fields": [ "abc", "def" ], "sparse": true, "inBackground": true }'
 
 // Also supported on fulltext and Geo indexes
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/fulltext?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/fulltext?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                            \
  -d '{ "type": "fulltext", "fields": [ "text" ], "minLength": 4, "inBackground": true }'
  
-curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?collection=collectioName' \
+curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/index/geo?collection=collectionName' \
  -H 'Authorization: bearer <token>'                                                                            \
  -d '{ "type": "geo", "fields": [ "latitude", "longitude" ], "minLength": 4, "inBackground": true }'
 ```

--- a/docs/collections/documents/indexing/working-with-indexes.md
+++ b/docs/collections/documents/indexing/working-with-indexes.md
@@ -106,7 +106,7 @@ curl -X 'POST' 'https://api-gdn.eng.macrometa.io/_fabric/_system/_api/document/c
  -d '{ tags: [ "foobar", "bar", "bar" ] }'
 ```
 
-This is done to avoid redudant storage of the same index value for the same document, which would not provide any benefit.
+This is done to avoid redundant storage of the same index value for the same document, which would not provide any benefit.
 
 If an array index is declared **unique**, the de-duplication of array values will happen before inserting the values into the index, so the above insert operation with two identical values `bar` will not necessarily fail
 

--- a/docs/collections/documents/indexing/working-with-indexes.md
+++ b/docs/collections/documents/indexing/working-with-indexes.md
@@ -1022,7 +1022,7 @@ If any of the explain methods shows that a query is not using indexes, the follo
 
 * check if the attribute names in the query are correctly spelled. In a schema-free database, documents in the same collection can have varying structures. There is no such thing as a `non-existing attribute` error. A query that refers to attribute names not present in any of the documents will not return an error, and obviously will not benefit from indexes.
 
-* check the value of the `Indexes Used` method for the collections used in the query and validate that indexes are actually present on the attributes used in the query's filter conditions. 
+* check the value of the `Indexes Used` method for the collections used in the query and validate that indexes are actually present on the attributes used in the query filter conditions. 
 
 * if indexes are present but not used by the query, the indexes may have the wrong type. For example, a hash index will only be used for equality comparisons (i.e. `==`) but not for other comparison types such as `<`, `<=`, `>`, `>=`. Additionally hash indexes will only be used if all of the index attributes are used in the query's FILTER conditions. A skiplist index will only be used if at least its first attribute is used in a FILTER condition. If additionally of the skiplist index attributes are specified in the query (from left-to-right), they may also be used and allow to filter more documents.
 


### PR DESCRIPTION
Replaced `ensureIndex` examples with `cURL` examples and `insert` with `POST Document` examples.