### PR TITLE
Fix caret style rendered for index.md directories

### DIFF
--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -212,6 +212,14 @@ div[class^='sidebar_'] .menu__link.menu__link--active:not(.menu__link--sublist) 
   @apply leading-6;
 }
 
+.menu__caret {
+  margin: 0;
+}
+
+.menu__caret:before {
+  background: var(--ifm-menu-link-sublist-icon) 50% / 1.25rem 1.25rem;
+}
+
 /* Optional style for only one link which acts as nav section header */
 
 .navbar__toggle {


### PR DESCRIPTION
## What does this PR do?

This PR fixes the left-nav caret sizing when rendered for directories w/ index.md files. This scenario produces slightly different markup, resulting in a slightly larger caret.

**Before**

<img width="272" alt="Screen Shot 2022-06-06 at 12 56 57 PM" src="https://user-images.githubusercontent.com/180438/172238250-84f55d03-4130-4bae-a339-0c4292f4b8d9.png">

**After**

<img width="273" alt="Screen Shot 2022-06-06 at 12 57 04 PM" src="https://user-images.githubusercontent.com/180438/172238257-cc78950c-92a0-485d-8a88-a662b88013ba.png">
