### PR TITLE
Add AWS link to dynamo.md

### DIFF
--- a/docs/tutorials/dynamo.md
+++ b/docs/tutorials/dynamo.md
@@ -3,6 +3,10 @@ sidebar_position: 17
 title: Dynamo Mode
 ---
 
+Dynamo tables are always created globally and written to the `_system` GeoFabric regardless of which GeoFabric received the API call.
+
+For more information, refer to the [Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/dynamodb-api.pdf#API_Operations_Amazon_DynamoDB) documentation.
+
 ## Prerequistes
 
 1. Create an API Key
@@ -232,8 +236,3 @@ This flag can be set in `_guestDBs` collection for the corresponding geofabric.
         --table-name Music \
         --endpoint-url https://api-gdn.paas.macrometa.io/_api/dynamo
 ```
-
-## Reference
-
-For more information, refer to the [Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/dynamodb-api.pdf#API_Operations_Amazon_DynamoDB) documentation.
-

--- a/docs/tutorials/dynamo.md
+++ b/docs/tutorials/dynamo.md
@@ -232,3 +232,8 @@ This flag can be set in `_guestDBs` collection for the corresponding geofabric.
         --table-name Music \
         --endpoint-url https://api-gdn.paas.macrometa.io/_api/dynamo
 ```
+
+## Reference
+
+For more information, refer to the [Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/dynamodb-api.pdf#API_Operations_Amazon_DynamoDB) documentation.
+

--- a/docs/tutorials/dynamo.md
+++ b/docs/tutorials/dynamo.md
@@ -5,7 +5,7 @@ title: Dynamo Mode
 
 Dynamo tables are always created globally and written to the `_system` GeoFabric regardless of which GeoFabric received the API call.
 
-For more information, refer to the [Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/dynamodb-api.pdf#API_Operations_Amazon_DynamoDB) documentation.
+For more information about Dynamo Mode, refer to the [Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/dynamodb-api.pdf#API_Operations_Amazon_DynamoDB) documentation.
 
 ## Prerequistes
 


### PR DESCRIPTION
Adding a reference link to AWS DynamoDB documentation in our Dynamo docs.