### PR TITLE
Renumbered top-level category folders

### DIFF
--- a/docs/apps/_category_.json
+++ b/docs/apps/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Sample Apps",
-  "position": 10
+  "position": 100
 }

--- a/docs/c8ql/_category_.json
+++ b/docs/c8ql/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "C8 Query Language",
-  "position": 8
+  "position": 80
 }

--- a/docs/cep/_category_.json
+++ b/docs/cep/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Stream Workers",
-  "position": 7
+  "position": 70
 }

--- a/docs/collections/_category_.json
+++ b/docs/collections/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Collections",
-  "position": 4
+  "position": 30
 }

--- a/docs/essentials/_category_.json
+++ b/docs/essentials/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Essentials",
-  "position": 3
+  "position": 20
 }

--- a/docs/queryworkers/_category_.json
+++ b/docs/queryworkers/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Query Workers",
-  "position": 5
+  "position": 50
 }

--- a/docs/references/_category_.json
+++ b/docs/references/_category_.json
@@ -1,5 +1,5 @@
 {
     "label": "References",
-    "position": 12
+    "position": 110
   }
   

--- a/docs/release-notes/_category_.json
+++ b/docs/release-notes/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Release Notes",
-  "position": 2
+  "position": 10
 }

--- a/docs/search/_category_.json
+++ b/docs/search/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Search",
-  "position": 4
+  "position": 40
 }

--- a/docs/streams/_category_.json
+++ b/docs/streams/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Streams",
-  "position": 6
+  "position": 60
 }

--- a/docs/tutorials/_category_.json
+++ b/docs/tutorials/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Tutorials",
-  "position": 9
+  "position": 90
 }


### PR DESCRIPTION
Changed all folder category numbers to two digits so that it is easier to reorder them in the future.