### PR TITLE
Remove slug from index

### DIFF
--- a/docs/essentials/index.md
+++ b/docs/essentials/index.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: Essentials
-slug: essentials
+
 ---
 
 Macrometa Global Data Network (GDN) is a geo-distributed, real-time, coordination-free materialized views engine. GDN supports multiple data models, making it flexible and compatible with many database types.

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,7 +1,6 @@
 ---
 sidebar_position: 10
 title: Release Notes
-slug: release-notes
 ---
 
 This section of the documentation contains information about the latest release of the Macrometa platform.

--- a/docs/search/index.md
+++ b/docs/search/index.md
@@ -1,7 +1,6 @@
 ---
 sidebar_position: 1
 title: Search
-slug: search
 ---
 
 Macrometa GDN Search (or *C8Search*) is a full-text search engine that supports key values, documents, and graphs as data models. Compared to a a [full-text index](../collections/documents/indexing/working-with-indexes#fulltext-indexes) C8Search is more configurable and customizable, combining Boolean and generalized ranking retrieval techniques to refine your search results. All Boolean-approved results are ranked by relevance to the respective query using the Vector Space Model in conjunction with BM25 or TF-IDF weighting schemes.


### PR DESCRIPTION
Removed slug from index.md, hoping it makes the link checker stop complaining.

As an added bonus, it will clean up some of our generated paths in the Docusaurus index docs.