### PR TITLE
Vercel config update

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,7 +13,7 @@ const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 
 const host = process.env.VERCEL_ENV && process.env.VERCEL_ENV === 'preview' ? `https://${process.env.VERCEL_URL}` : 'https://macrometa.com';
-const isDev = process.env.NODE_ENV === 'development' || (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'production');
+const isDev = process.env.NODE_ENV === 'development' || process.env.VERCEL_ENV;
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {


### PR DESCRIPTION
This PR omits the `/docs/` path segment for all Vercel deploys.