### PR TITLE
Fixing Tab view not available on streamworker example page

### DIFF
--- a/docs/cep/stream-workers-example.md
+++ b/docs/cep/stream-workers-example.md
@@ -3,6 +3,8 @@ sidebar_position: 10
 title: Stream Workers Example
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 Assume the following credentials:
 
@@ -629,7 +631,7 @@ The following example uses the code snippets provided in this tutorial.
             @info(name='Dump')
             INSERT INTO SampleCargoAppDestTable
             SELECT weight
-            FROM SampleCargoAppInputTable;
+            FROM SampleCargoAppInputTable;`
       
             const app = client.streamApp("Sample-Cargo-App");
             ressult = await app.retriveApplication();


### PR DESCRIPTION
Tab view for code blocks not available in the following page:
https://macrometa.com/docs/cep/stream-workers-example

Fixing the same, turns out there was a small missing part of importing here. Also there was a ending backtick missing in the last piece of js code snippet.

