### PR TITLE
add ga to docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -45,6 +45,9 @@ const config = {
           changefreq: 'weekly',
           priority: 0.5,
         },
+        gtag: {
+          trackingID: process.env.GTAG_TRACKING_ID || "DEV",
+        },
       },
     ],
   ],


### PR DESCRIPTION
Google Analytics was not enabled on the new docs site. This PR enables them