### PR TITLE
Change top-level sidebar positions to double digits

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 60
 title: Authentication
 slug: authentication
 ---

--- a/docs/geofabrics.md
+++ b/docs/geofabrics.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 70
 title: GeoFabrics
 slug: geofabrics
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 10
 title: Quickstart
 ---
 

--- a/docs/sdks.md
+++ b/docs/sdks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 40
 title: SDKs
 slug: sdks
 ---

--- a/docs/what-is-macrometa.md
+++ b/docs/what-is-macrometa.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 30
 title: What is Macrometa
 ---
 


### PR DESCRIPTION
This PR updates the top-level docs (quick start, authentication, etc.) so the sidebar positions are double-digit instead of single-digit