### PR TITLE
Changes for updateItem DynamoDb

### DIFF
--- a/docs/collections/dynamo/reference/mmdynamo/updateAnItem.md
+++ b/docs/collections/dynamo/reference/mmdynamo/updateAnItem.md
@@ -55,7 +55,7 @@ Save as .html and open the file in your browser.
             ":p": "Everything happens all at once.",
             ":a": ["Larry", "Moe", "Curly"],
           },
-          ReturnValues: "UPDATED_NEW",
+          ReturnValues: "ALL_NEW",
         };
 
         client.updateItem(params, function (err, data) {

--- a/docs/collections/dynamo/reference/updateAnItem.md
+++ b/docs/collections/dynamo/reference/updateAnItem.md
@@ -50,7 +50,7 @@ Save as .html and open the file in your browser.
             ":p": "Everything happens all at once.",
             ":a": ["Larry", "Moe", "Curly"],
           },
-          ReturnValues: "UPDATED_NEW",
+          ReturnValues: "ALL_NEW",
         };
 
         docClient.update(params, function (err, data) {
@@ -133,7 +133,7 @@ function updateItem() {
       ":p": "Everything happens all at once.",
       ":a": ["Larry", "Moe", "Curly"],
     },
-    ReturnValues: "UPDATED_NEW",
+    ReturnValues: "ALL_NEW",
   };
 
   console.log("Updating the item...");

--- a/docs/collections/dynamo/using-aws-boto3.md
+++ b/docs/collections/dynamo/using-aws-boto3.md
@@ -196,7 +196,7 @@ def update_movie(dynamodb=None):
                 ":r": {"N":"5.5"},
                 ":p": {"S":"Everything happens all at once."},
             },
-            ReturnValues= "UPDATED_OLD"
+            ReturnValues= "ALL_NEW"
         )
         print("Update movie: ", resp)
 

--- a/docs/collections/dynamo/using-aws-js-browser.md
+++ b/docs/collections/dynamo/using-aws-js-browser.md
@@ -521,7 +521,7 @@ Copy the following program and paste it into a file named `MoviesItemOps03.html`
                 ":p":"Everything happens all at once.",
                 ":a":["Larry", "Moe", "Curly"]
             },
-            ReturnValues:"UPDATED_NEW"
+            ReturnValues:"ALL_NEW"
         };
 
         docClient.update(params, function(err, data) {
@@ -547,7 +547,7 @@ Copy the following program and paste it into a file named `MoviesItemOps03.html`
 
 :::note
 * This program uses UpdateExpression to describe all updates you want to perform on the specified item.
-* The ReturnValues parameter instructs Amazon DynamoDB to return only the updated attributes ("UPDATED_NEW").
+* The ReturnValues parameter instructs Amazon DynamoDB to return all the attributes of the item, as they appear after the update operation ("ALL_NEW").
 :::
 
 Open the `MoviesItemOps03.html` file in your browser and choose `Update Item`.
@@ -612,7 +612,7 @@ Copy the following program and paste it into a file named `MoviesItemOps04.html`
             ExpressionAttributeValues:{
                 ":val":1
             },
-            ReturnValues:"UPDATED_NEW"
+            ReturnValues:"ALL_NEW"
         };
 
         docClient.update(params, function(err, data) {
@@ -701,7 +701,7 @@ Copy the following program and paste it into a file named `MoviesItemOps05.html`
                 ExpressionAttributeValues:{
                     ":num":3
                 },
-                ReturnValues:"UPDATED_NEW"
+                ReturnValues:"ALL_NEW"
             };
     
             docClient.update(params, function(err, data) {

--- a/docs/collections/dynamo/using-aws-js-nodejs.md
+++ b/docs/collections/dynamo/using-aws-js-nodejs.md
@@ -414,11 +414,13 @@ Copy the following program and paste it into a file named `MoviesItemOps03.js`.
             "year": year,
             "title": title
         },
-        UpdateExpression: "set info = :rpa",
+        UpdateExpression: "set info.rating = :r, info.plot=:p, info.actors=:a",
         ExpressionAttributeValues:{
-            ":rpa": {actors: ["Larry", "Moe", "Curly"], rating: 5.5, plot: "Everything happens all at once."}
+            ":r": 6.5,
+            ":p": "Everything happens all at once.",
+            ":a": ["Larry", "Moe", "Curly"],
         },
-        ReturnValues:"UPDATED_NEW"
+        ReturnValues:"ALL_NEW"
     };
 
     console.log("Updating the item...");
@@ -433,7 +435,7 @@ Copy the following program and paste it into a file named `MoviesItemOps03.js`.
 
 :::note
 * This program uses `UpdateExpression` to describe all updates you want to perform on the specified item.
-* The `ReturnValues` parameter instructs Amazon DynamoDB to return only the updated attributes ("UPDATED_NEW").
+* The `ReturnValues` parameter instructs Amazon DynamoDB to return all the attributes of the item, as they appear after the update operation ("ALL_NEW").
 :::
 
 To run the program, enter the following command.
@@ -492,7 +494,7 @@ Copy the following program and paste it into a file named `MoviesItemOps04.js`.
         ExpressionAttributeValues:{
             ":val": 1
         },
-        ReturnValues:"UPDATED_NEW"
+        ReturnValues:"ALL_NEW"
     };
 
     console.log("Updating the item...");
@@ -562,7 +564,7 @@ Copy the following program and paste it into a file named `MoviesItemOps05.js`.
         ExpressionAttributeValues:{
             ":num": 3
         },
-        ReturnValues:"UPDATED_NEW"
+        ReturnValues:"ALL_NEW"
     };
 
     console.log("Attempting a conditional update...");


### PR DESCRIPTION
Changing UPDATED_NEW and UPDATED_OLD to RETURN_NEW (so that user never gets confused whether the remaining attributes have been overwritten or don't exist because we had a previous such case where we were overwriting the not updated values)

Also corrected the update expression in usingaws-jsnodejs example.