### PR TITLE
Adding consumes and produces global MIME types

### DIFF
--- a/static/swagger/spec.json
+++ b/static/swagger/spec.json
@@ -12633,7 +12633,6 @@
             "name": "JSON Request Body",
             "required": true,
             "schema": {
-              "type": "object",
               "example": [
                 {
                   "_key": "key1",
@@ -12769,10 +12768,6 @@
             "name": "JSON Request Body",
             "required": true,
             "schema": {
-              "type": "array",
-              "items": {
-                "type": "object"
-              },
               "example": [
                 {
                   "item1": "data1"
@@ -12899,7 +12894,6 @@
             "name": "JSON Request Body",
             "required": true,
             "schema": {
-              "type": "object",
               "example": [
                 {
                   "_key": "key1",
@@ -13252,7 +13246,6 @@
             "name": "JSON Request Body",
             "required": true,
             "schema": {
-              "type": "object",
               "example": {
                 "_key": "key1",
                 "item1": "data1"
@@ -13394,7 +13387,6 @@
             "name": "JSON Request Body",
             "required": true,
             "schema": {
-              "type": "object",
               "example": {
                 "item1": "data1"
               }
@@ -16040,7 +16032,6 @@
             "name": "JSON Request Body",
             "required": true,
             "schema": {
-              "type": "object",
               "example": {
                 "data": 1234
               }
@@ -16434,7 +16425,6 @@
             "name": "JSON Request Body",
             "required": true,
             "schema": {
-              "type": "object",
               "example": {
                 "collection": "demo1"
               }
@@ -16740,7 +16730,6 @@
             "name": "JSON Request Body",
             "required": true,
             "schema": {
-              "type": "object",
               "example": {
                 "data": "demo1"
               }
@@ -16860,7 +16849,6 @@
             "name": "JSON Request Body",
             "required": true,
             "schema": {
-              "type": "object",
               "example": {
                 "data": "demo1"
               }

--- a/static/swagger/spec.json
+++ b/static/swagger/spec.json
@@ -22,6 +22,12 @@
       "ApiKeyAuth": []
     }
   ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
   "definitions": {
     "document_get_412": {
       "properties": {
@@ -10218,12 +10224,6 @@
     "title": "Macrometa GDN API",
     "version": ""
   },
-  "consumes": [
-    "application/json"
-  ],
-  "produces": [
-    "application/json"
-  ],
   "paths": {
     "/_api/key/validate": {
       "post": {

--- a/static/swagger/spec.json
+++ b/static/swagger/spec.json
@@ -10218,6 +10218,12 @@
     "title": "Macrometa GDN API",
     "version": ""
   },
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
   "paths": {
     "/_api/key/validate": {
       "post": {


### PR DESCRIPTION
This will enable us to see the Request and Response Body sample in the "Send API Request" Demo (TryIt model of stoplight) for all APIs in the public API references