### PR TITLE
Remove C8 from docs

### DIFF
--- a/docs/c8ql/coming-from-sql.md
+++ b/docs/c8ql/coming-from-sql.md
@@ -38,7 +38,7 @@ INSERT document
 
 Refer to [INSERT](../c8ql/operations/insert.md) for more details.
 
-### Inserting a single row / document:
+### Inserting a single row / document
 
 SQL:
 
@@ -54,7 +54,7 @@ C8QL:
     INTO users
  ```
 
-### Inserting multiple rows / documents:
+### Inserting multiple rows / documents
 
 SQL:
 
@@ -74,7 +74,7 @@ C8QL:
     INSERT user INTO users
  ```
 
-### Inserting rows / documents from a table / collection:
+### Inserting rows / documents from a table / collection
 
 SQL:
 
@@ -124,8 +124,7 @@ UPDATE keyExpression WITH document IN collection options
 
 Refer to [UPDATE](../c8ql/operations/update.md) for more details.
 
-
-### Updating a single row / document:
+### Updating a single row / document
 
 SQL:
 
@@ -195,7 +194,7 @@ FOR user IN users
 
 ### Adding optional columns / attributes
 
-SQL: 
+SQL:
 
 ```sql
 ALTER TABLE users 
@@ -237,7 +236,7 @@ LET date = DATE_NOW()
       IN users
 ```
 
-### Removing a column / attribute:
+### Removing a column / attribute
 
 SQL:
 
@@ -296,8 +295,7 @@ The REPLACE keyword completely modifies documents in a collection. There are two
 
 Refer to [REPLACE](../c8ql/operations/replace.md) for more details.
 
-
-### Replacing a single row / document:
+### Replacing a single row / document
 
 SQL:
 
@@ -318,7 +316,7 @@ REPLACE { _key: "1" }
   IN users
 ```
 
-### Replacing multiple rows / documents in a table:
+### Replacing multiple rows / documents in a table
 
 SQL:
 
@@ -345,7 +343,7 @@ SQL uses DELETE statements to remove rows from a table. In C8QL, the REMOVE keyw
 
 Refer to [REMOVE](../c8ql/operations/remove.md) for more details.
 
-### Deleting a single row / document:
+### Deleting a single row / document
 
 SQL:
 
@@ -386,8 +384,7 @@ Here, `FOR` iterates over documents in a collection. `RETURN` determines what th
 
 Refer to [FOR](../c8ql/operations/for.md) for more details.
 
-
-### Selecting all rows / documents from a table / collection, with all columns / attributes:
+### Selecting all rows / documents from a table / collection, with all columns / attributes
 
 SQL:
 
@@ -403,7 +400,7 @@ FOR user IN users
   RETURN user
 ```
 
-### Filtering rows / documents from a table / collection, with projection:
+### Filtering rows / documents from a table / collection, with projection
 
 SQL:
 
@@ -414,6 +411,7 @@ SELECT CONCAT(firstName, " ", lastName)
 ```
 
 C8QL:
+
 ```js
 FOR user IN users
   FILTER user.active == 1
@@ -424,7 +422,7 @@ FOR user IN users
   }
 ```
 
-### Sorting rows / documents from a table / collection:
+### Sorting rows / documents from a table / collection
 
 SQL:
 
@@ -449,8 +447,7 @@ There are a series of functions and clauses in both SQL and C8QL to group or fur
 
 Refer to [COLLECT](../c8ql/operations/collect.md) for more details.
 
-
-### Counting rows / documents in a table / collection:
+### Counting rows / documents in a table / collection
 
 Both SQL and C8QL can count the rows or documents in the result-set and tell you how many it finds. C8QL manages counts using the `WITH` keyword to count the documents into a return variable.
 
@@ -475,7 +472,7 @@ FOR user IN users
   }
 ```
 
-### Grouping rows / documents in a table / collection:
+### Grouping rows / documents in a table / collection
 
 In SQL, the `GROUP BY` clauses collects the result-set according to the given column. C8QL replaces this with the `COLLECT` keyword.
 
@@ -508,7 +505,7 @@ FOR user IN users
     }
 ```
 
-### Minimum, maximum calculation of rows / documents in a table / collection:
+### Minimum, maximum calculation of rows / documents in a table / collection
 
 Both SQL and C8QL use functions to find the minimum and maximum values for a given field. In C8QL, it’s handled with the `COLLECT` keyword.
 
@@ -532,9 +529,9 @@ FOR user IN users
   RETURN { minDate, maxDate }
 ```
 
-### Building horizontal lists:
+### Building horizontal lists
 
-SQL: 
+SQL:
 
 ```sql
 SELECT gender, GROUP_CONCAT(id) AS userIds 
@@ -561,9 +558,9 @@ FOR user IN users
 
 ## JOINS
 
-Similar to joins in relational databases, C8 has its own implementation of `JOINS`. Coming from an SQL background, you may find the C8QL syntax very different from your expectations.
+Similar to joins in relational databases, C8QL has its own implementation of `JOINS`. Coming from an SQL background, you might find the C8QL syntax very different from your expectations.
 
-### Inner join:
+### Inner join
 
 SQL:
 
@@ -642,13 +639,13 @@ FOR user IN users
 
 In the main, C8QL is a declarative language. Queries express what results you want but not how you want to get there. C8QL aims to be human-readable, therefore uses keywords from the English language.
 
-It also aims to be client independent, meaning that the language and syntax are the same for all clients, no matter what programming language the clients use. Additionally, it supports complex query patterns and the various data models C8 offers.
+It also aims to be client independent, meaning that the language and syntax are the same for all clients, no matter what programming language the clients use. Additionally, it supports complex query patterns and the various data models Macrometa offers.
 
-C8QL also supports several aggregation and string functions. For more information, see [C8QL Functions](coming-from-sql.md)
+C8QL also supports several aggregation and string functions. For more information, see [C8QL Functions](coming-from-sql.md).
 
 ## How do browse vectors translate into document queries?
 
-In traditional SQL you may either fetch all columns of a table row by row, using `SELECT * FROM table`, or select a subset of the columns. The list of table columns to fetch is commonly called *column list* or *browse vector*:
+In traditional SQL you may either fetch all columns of a table row by row, using `SELECT * FROM table`, or select a subset of the columns. The list of table columns to fetch is commonly called _column list_ or _browse vector_:
 
 ```sql
 SELECT columnA, columnB, columnZ FROM table
@@ -660,13 +657,14 @@ C8QL is thus a little bit more complex than plain SQL at first, but offers much 
 
 ## Composing the documents to be returned
 
-The C8QL `RETURN` statement returns one item per document it is handed. You can return the whole document, or just parts of it. 
+The C8QL `RETURN` statement returns one item per document it is handed. You can return the whole document, or just parts of it.
 
 Given that _oneDocument_ is a document (retrieved like `LET oneDocument = DOCUMENT("myusers/3456789")` for instance), it can be returned as-is like this:
 
 ```js
 RETURN oneDocument
 ```
+
 The above statement returns a document like:
 
 ```json

--- a/docs/c8ql/coming-from-sql.md
+++ b/docs/c8ql/coming-from-sql.md
@@ -13,7 +13,6 @@ Though some of the keywords overlap, C8QL syntax differs from SQL. For instance,
 
 Despite few differences, anyone with an SQL background should have no difficulty in learning C8QL.
 
-
 ## Terminology
 
 Below is a table with the terms of both systems.

--- a/docs/c8ql/graphs/index.md
+++ b/docs/c8ql/graphs/index.md
@@ -7,10 +7,10 @@ There are multiple ways to work with graphs in GDN, as well as different ways to
 
 The two options in managing graphs are to either use
 
-- named graphs where C8 manages the collections involved in one graph, or
+- named graphs where Macrometa manages the collections involved in one graph, or
 - graph functions on a combination of document and edge collections.
 
-Named graphs can be defined through the graph-module or via the web interface. The definition contains the name of the graph, and the vertex and edge collections involved. Since the management functions are layered on top of simple sets of document and edge collections, you can also use regular C8QL functions to work with them. 
+Named graphs can be defined through the graph-module or via the web interface. The definition contains the name of the graph, and the vertex and edge collections involved. Since the management functions are layered on top of simple sets of document and edge collections, you can also use regular C8QL functions to work with them.
 
 Both variants (named graphs and loosely coupled collection sets a.k.a. anonymous graphs) are supported by the C8QL language constructs for graph querying. These constructs make full use of optimizations and therefore best performance is to be expected:
 

--- a/docs/c8ql/index.md
+++ b/docs/c8ql/index.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: C8QL
 ---
 
-# C8 query language (C8QL)
+# C8 Query Language (C8QL)
 
 The C8 query language (C8QL) can be used to create, retrieve and modify data that are stored in C8 Geo distributed fast data platform.
 
@@ -13,13 +13,13 @@ If this is your first time with C8QL then be sure to check out the [**C8QL Tutor
 
 The general workflow when executing a query is as follows:
 
-- A client application ships a C8QL query to the C8  fabric. The query text contains everything C8 needs to compile the result set
+- A client application ships a C8QL query to the fabric. The query text contains everything Macrometa needs to compile the result set.
 
-- C8 will parse the query, execute it and compile the results. If the query is invalid or cannot be executed, the server will return an error that the client can process and react to. If the query can be executed successfully, the server will return the query results (if any) to the client
+- Macrometa will parse the query, execute it and compile the results. If the query is invalid or cannot be executed, the server will return an error that the client can process and react to. If the query can be executed successfully, the server will return the query results (if any) to the client.
 
 C8QL is mainly a declarative language, meaning that a query expresses what result should be achieved but not how it should be achieved. C8QL aims to be human-readable and therefore uses keywords from the English language.
 
-Another design goal of C8QL was client independency, meaning that the language and syntax are the same for all clients, no matter what programming language the clients may use.  Further design goals of C8QL were the support of complex query patterns and the different data models C8 offers.
+Another design goal of C8QL was client independency, meaning that the language and syntax are the same for all clients, no matter what programming language the clients may use.  Further design goals of C8QL were the support of complex query patterns and the different data models Macrometa offers.
 
 In its purpose, C8QL is similar to the Structured Query Language (SQL). C8QL supports reading and modifying collection data, but it doesn't support data-definition operations such as creating and dropping databases, collections and indexes.
 

--- a/docs/c8ql/index.md
+++ b/docs/c8ql/index.md
@@ -5,7 +5,7 @@ title: C8QL
 
 # C8 Query Language (C8QL)
 
-The C8 query language (C8QL) can be used to create, retrieve and modify data that are stored in C8 Geo distributed fast data platform.
+The C8 query language (C8QL) can be used to create, retrieve and modify data that are stored in the Macrometa geo-distributed fast data platform.
 
 :::note
 If this is your first time with C8QL then be sure to check out the [**C8QL Tutorial**](c8ql-tutorial.md) before you head off to the in-depth documentation!

--- a/docs/collections/documents/geospatial/index.md
+++ b/docs/collections/documents/geospatial/index.md
@@ -11,8 +11,8 @@ Calculating e.g. the distance between two coordinate tuples or checking whether 
 
 Of course, speed is not everything, so we also want to provide a broader set of geo functionality by integrating full GeoJSON support including `Polygons`, `Multi-Polygons` and other geometry primitives.
 
-With these functionalities, one can do more complex queries and build e.g. location-aware recommendation engines by combining the graph data model with geo-location aspects or use multiple data models. 
+With these functionalities, one can do more complex queries and build e.g. location-aware recommendation engines by combining the graph data model with geo-location aspects or use multiple data models.
 
 For instance, in the age of self-driving cars, one can find the nearest available maintenance team (geo query) with the right permission (graph model) to repair a given problem (sent automatically to the DB as e.g. a JSON document or key/value pair).
 
-Geospatial coordinates consisting of a latitude and longitude value can be stored either as two separate attributes, or as a single attribute in the form of an array with both numeric values. C8 can [index such coordinates](../../indexing/working-with-indexes#geo-spatial-indexes) for fast geospatial queries.
+Geospatial coordinates consisting of a latitude and longitude value can be stored either as two separate attributes, or as a single attribute in the form of an array with both numeric values. Macrometa can [index such coordinates](../../indexing/working-with-indexes#geo-spatial-indexes) for fast geospatial queries.

--- a/docs/collections/dynamo/reference/mmdynamo/readme.md
+++ b/docs/collections/dynamo/reference/mmdynamo/readme.md
@@ -1,4 +1,4 @@
-# Connect to dynamodb C8 using mmdynamo
+# Connect to dynamodb Macrometa using mmdynamo
 
 ## Browser(Javascript) NPM
 
@@ -56,7 +56,7 @@
    <script src="https://unpkg.com/mmdynamo@0.2.0/dist/mmdynamo.umd.js"></script>
    ```
 
-2. Initialize Dynamodb with C8 Dynamo
+2. Initialize Dynamodb
 
    ```html
    <script type="text/javascript">

--- a/docs/collections/dynamo/reference/readme.md
+++ b/docs/collections/dynamo/reference/readme.md
@@ -21,7 +21,7 @@
    import DynamoDB from "aws-sdk/clients/dynamodb";
    ```
 
-3. Initialize Dynamodb with C8 Dynamo
+3. Initialize Dynamodb with Macrometa Dynamo
 
    ```js
    import AWS from "aws-sdk";
@@ -69,7 +69,7 @@ If you want to sign and send AWS requests in a modern browser, or an environment
    <script src="https://sdk.amazonaws.com/js/aws-sdk-2.7.16.min.js"></script>
    ```
 
-2. Initialize Dynamodb with C8 Dynamo
+2. Initialize Dynamodb with Macrometa Dynamo
 
    ```html
    <script type="text/javascript">

--- a/docs/collections/dynamo/using-mmdynamo-browser.md
+++ b/docs/collections/dynamo/using-mmdynamo-browser.md
@@ -4,19 +4,19 @@ title: Using mmDynamo Javascript SDK
 ---
 ## Browser(Javascript) NPM
 
-* Install `mmdynamo`
+- Install `mmdynamo`
 
   ```js
   npm install mmdynamo --save
   ```
 
-* Import package
+- Import package
 
   ```js
   import { DynamoDB } from "mmdynamo";
   ```
 
-* Initialize Dynamodb
+- Initialize Dynamodb
 
   ```js
   import { DynamoDB } from "mmdynamo";
@@ -52,13 +52,13 @@ title: Using mmDynamo Javascript SDK
 
 ## Browser(Javascript) as Library
 
-* Add `mmdynamo`
+- Add `mmdynamo`
 
   ```html
   <script src="https://unpkg.com/mmdynamo@0.2.0/dist/mmdynamo.umd.js"></script>
   ```
 
-* Initialize Dynamodb with C8 DynamoMode
+- Initialize Dynamodb with Macrometa DynamoMode
 
   ```html
   <script type="text/javascript">
@@ -93,7 +93,6 @@ title: Using mmDynamo Javascript SDK
     });
   </script>
   ```
-
 
 ## Create a Table
 
@@ -440,8 +439,8 @@ const client = new DynamoDB({
 </html>
 ```
 
-
 ## Query Data
+
 ```html
 
 <html>
@@ -535,6 +534,7 @@ function queryData() {
   </body>
 </html>
 ```
+
 ## Scan Data
 
 ```html

--- a/docs/collections/graphs/quickstart.md
+++ b/docs/collections/graphs/quickstart.md
@@ -464,7 +464,7 @@ A graph consists of `vertices` and `edges`. Vertices are stored as documents in 
 
     pp = pprint.PrettyPrinter(indent=4)
 
-    # Initialize the C8 Data Fabric client.
+    # Initialize the Data Fabric client.
     # Step1: Open connection to GDN. You will be routed to closest region.
     print(f"1. CONNECT: federation: {GLOBAL_URL},  user: {EMAIL}")
     

--- a/docs/queryworkers/data-modification-queries.md
+++ b/docs/queryworkers/data-modification-queries.md
@@ -30,7 +30,7 @@ INSERT {
 } IN users
 ```
 
-You may provide a key for the new document; if not provided, C8 will create one for you.  
+You can provide a key for the new document. If not provided, then Macrometa creates one for you.  
 
 ```js
 INSERT {
@@ -41,7 +41,7 @@ INSERT {
 } IN users
 ```
 
-As C8 is schema-free, attributes of the documents may vary:
+As Macrometa is schema-free, attributes of the documents may vary:
 
 ```js
 INSERT {
@@ -154,7 +154,7 @@ In all cases the full documents will be returned with all their attributes, incl
 
 ## Restrictions
 
-The name of the modified collection (*users* and *backup* in the above cases) must be known to the C8QL executor at query-compile time and cannot change at runtime. Using a bind parameter to specify the collection name is allowed.
+The name of the modified collection (_users_ and _backup_ in the above cases) must be known to the C8QL executor at query-compile time and cannot change at runtime. Using a bind parameter to specify the collection name is allowed.
 
 Data-modification operations are restricted to one collection at a time. It is not possible to use multiple data-modification operations for the same collection in the same query, or follow up a data-modification operation for a specific collection with a read operation for the same collection. Neither is it possible to follow up any data-modification operation with a traversal query (which may read from arbitrary collections not necessarily known at the start of the traversal).
 

--- a/docs/queryworkers/query-errors.md
+++ b/docs/queryworkers/query-errors.md
@@ -4,7 +4,7 @@ title: Query Errors
 
 This page describes errors that might occur during the C8QL parsing or execution.
 
-Issuing an invalid query to the server will result in a parse error if the query is syntactically invalid. C8 will detect such errors during query inspection and abort further processing. Instead, the error number and an error message are returned so that the errors can be fixed.
+Issuing an invalid query to the server will result in a parse error if the query is syntactically invalid. Macrometa detects such errors during query inspection and abort further processing. Instead, the error number and an error message are returned so that the errors can be fixed.
 
 If a query passes the parsing stage, all collections referenced in the query will be opened. If any of the referenced collections is not present, query execution will again be aborted and an appropriate error message will be returned.
 

--- a/docs/references/naming-conventions.md
+++ b/docs/references/naming-conventions.md
@@ -41,7 +41,7 @@ Users can pick attribute names for document attributes as desired, provided the 
 
 - Attribute names starting with an at-mark (_@_) will need to be enclosed in backticks when used in a C8QL query to tell them apart from bind variables. Therefore we do not encourage the use of attributes starting with at-marks, though they will work when used properly.
 
-- C8 does not enforce a length limit for attribute names. However, long attribute names may use more memory in result sets etc. Therefore the use of long attribute names is discouraged.
+- Macrometa does not enforce a length limit for attribute names. However, long attribute names may use more memory in result sets etc. Therefore the use of long attribute names is discouraged.
 
 - Attribute names are case-sensitive.
 
@@ -59,7 +59,7 @@ Users can define their own keys for documents they save. The document key will b
 
 Keys are case-sensitive, i.e. `myKey` and `MyKEY` are considered to be different keys.
 
-Specifying a document key is optional when creating new documents. If no document key is specified by the user, C8 will create the document key itself as each document is required to have a key.
+Specifying a document key is optional when creating new documents. If no document key is specified by the user, then Macrometa will create the document key itself as each document is required to have a key.
 
 There are no guarantees about the format and pattern of auto-generated document keys other than the above restrictions. Clients should therefore treat auto-generated document keys as opaque values and not rely on their format.
 

--- a/docs/references/naming-conventions.md
+++ b/docs/references/naming-conventions.md
@@ -7,21 +7,21 @@ The following naming conventions should be followed by users when creating geo-f
 
 ## GeoFabric Names
 
-C8 will always start up with a default GeoFabrics, named `_system`. Users can create additional GeoFabrics in C8, provided the fabric names conform to the following constraints:
+Macrometa will always start up with a default GeoFabrics, named `_system`. Users can create additional GeoFabrics in C8, provided the fabric names conform to the following constraints:
 
-* Fabric names must only consist of the letters `a` to `z` (both lower and upper case allowed), the numbers `0` to `9`. This also means that any non-ASCII database names are not allowed.
-* Fabric names must always start with a letter. Fabric names starting with an underscore are considered to be system fabrics, and users should not create or delete those.
-* The maximum allowed length of a fabric name is 64 bytes.
-* Fabric names are case-sensitive.
+- Fabric names must only consist of the letters `a` to `z` (both lower and upper case allowed), the numbers `0` to `9`. This also means that any non-ASCII database names are not allowed.
+- Fabric names must always start with a letter. Fabric names starting with an underscore are considered to be system fabrics, and users should not create or delete those.
+- The maximum allowed length of a fabric name is 64 bytes.
+- Fabric names are case-sensitive.
 
 ## Collection Names
 
 Users can pick names for their collections as desired, provided the following naming constraints are not violated:
 
-* Collection names must only consist of the letters `a` to `z` (both in lower and upper case) and the numbers `0` to `9`. This also means that any non-ASCII collection names are not allowed
-* User-defined collection names must always start with a letter. System collection names must start with an underscore. All collection names starting with an underscore are considered to be system collections that are for C8's internal use only. System collection names should not be used by end users for their own collections
-* The maximum allowed length of a collection name is 64 bytes
-* Collection names are case-sensitive
+- Collection names must only consist of the letters `a` to `z` (both in lower and upper case) and the numbers `0` to `9`. This also means that any non-ASCII collection names are not allowed
+- User-defined collection names must always start with a letter. System collection names must start with an underscore. All collection names starting with an underscore are considered to be system collections that are for C8's internal use only. System collection names should not be used by end users for their own collections
+- The maximum allowed length of a collection name is 64 bytes
+- Collection names are case-sensitive
 
 ## Attribute Names
 
@@ -37,25 +37,25 @@ Users can pick attribute names for document attributes as desired, provided the 
 
   Do not use an underscore at the start of custom attribute names.
 
-* Theoretically, attribute names can include punctuation and special characters as desired, provided the name is a valid UTF-8 string.  For maximum portability, special characters should be avoided though.  For example, attribute names may contain the dot symbol, but the dot has a special meaning in JavaScript and also in C8QL, so when using such attribute names in one of these languages, the attribute name needs to be quoted by the end user. Overall it might be better to use attribute names which don't require any quoting/escaping in all languages used. This includes languages used by the client (e.g. Ruby, PHP) if the attributes are mapped to object members there.
+- Theoretically, attribute names can include punctuation and special characters as desired, provided the name is a valid UTF-8 string.  For maximum portability, special characters should be avoided though.  For example, attribute names may contain the dot symbol, but the dot has a special meaning in JavaScript and also in C8QL, so when using such attribute names in one of these languages, the attribute name needs to be quoted by the end user. Overall it might be better to use attribute names which don't require any quoting/escaping in all languages used. This includes languages used by the client (e.g. Ruby, PHP) if the attributes are mapped to object members there.
 
-* Attribute names starting with an at-mark (*@*) will need to be enclosed in backticks when used in a C8QL query to tell them apart from bind variables. Therefore we do not encourage the use of attributes starting with at-marks, though they will work when used properly.
+- Attribute names starting with an at-mark (_@_) will need to be enclosed in backticks when used in a C8QL query to tell them apart from bind variables. Therefore we do not encourage the use of attributes starting with at-marks, though they will work when used properly.
 
-* C8 does not enforce a length limit for attribute names. However, long attribute names may use more memory in result sets etc. Therefore the use of long attribute names is discouraged.
+- C8 does not enforce a length limit for attribute names. However, long attribute names may use more memory in result sets etc. Therefore the use of long attribute names is discouraged.
 
-* Attribute names are case-sensitive.
+- Attribute names are case-sensitive.
 
-* Attributes with empty names (an empty string) are disallowed.
+- Attributes with empty names (an empty string) are disallowed.
 
 ## Document Keys
 
 Users can define their own keys for documents they save. The document key will be saved along with a document in the `_key` attribute. Users can pick key values as required, provided that the values conform to the following restrictions:
 
-* The key must be a string value. Numeric keys are not allowed, but any numeric value can be put into a string and can then be used as document key.
-* The key must be at least 1 byte and at most 254 bytes long. Empty keys are disallowed when specified (though it may be valid to completely omit the *_key* attribute from a document)
-* It must consist of the letters a-z (lower or upper case), the digits 0-9 or any of the following punctuation characters: `_` `-` `:` `.` `@` `(` `)` `+` `,` `=` `;` `$` `!` `*` `'` `%` 
-* Any other characters, especially multi-byte UTF-8 sequences, whitespace or punctuation characters cannot be used inside key values
-* The key must be unique within the collection it is used
+- The key must be a string value. Numeric keys are not allowed, but any numeric value can be put into a string and can then be used as document key.
+- The key must be at least 1 byte and at most 254 bytes long. Empty keys are disallowed when specified (though it may be valid to completely omit the __key_ attribute from a document)
+- It must consist of the letters a-z (lower or upper case), the digits 0-9 or any of the following punctuation characters: `_` `-` `:` `.` `@` `(` `)` `+` `,` `=` `;` `$` `!` `*` `'` `%`
+- Any other characters, especially multi-byte UTF-8 sequences, whitespace or punctuation characters cannot be used inside key values
+- The key must be unique within the collection it is used
 
 Keys are case-sensitive, i.e. `myKey` and `MyKEY` are considered to be different keys.
 

--- a/docs/streams/index.md
+++ b/docs/streams/index.md
@@ -41,7 +41,7 @@ Messages are the basic `unit` of GDN streams. They're what producers publish to 
 
 ## Producers
 
-A producer is a process that attaches to a stream and publishes messages to a C8 for processing.
+A producer is a process that attaches to a stream and publishes messages to a stream for processing.
 
 ### Send modes
 
@@ -54,10 +54,10 @@ Producers can send messages to GDN  either synchronously (sync) or asynchronousl
 
 ### Compression
 
-Messages published by producers can be compressed during transportation in order to save bandwidth. C8 streams currently supports two types of compression:
+Messages published by producers can be compressed during transportation in order to save bandwidth. Macrometa streams currently supports two types of compression:
 
-* [LZ4](https://github.com/lz4/lz4)
-* [ZLIB](https://zlib.net/)
+- [LZ4](https://github.com/lz4/lz4)
+- [ZLIB](https://zlib.net/)
 
 ### Batching
 
@@ -69,7 +69,7 @@ A consumer is a process that attaches to a stream via a subscription and then re
 
 ### Receive modes
 
-Messages can be received from C8  either synchronously (sync) or asynchronously (async).
+Messages can be received from streams either synchronously (sync) or asynchronously (async).
 
 | Mode          | Description  |
 |--------------|---------------------------|
@@ -85,6 +85,7 @@ Messages can be acknowledged either one by one or cumulatively. With cumulative 
 :::note
 Cumulative acknowledgement cannot be used with `shared subscription mode`, because shared mode involves multiple consumers having access to the same subscription.
 :::
+
 ### Listeners
 
 Client libraries can provide their own listener implementations for consumers. In this interface, the `received` method is called whenever a new message is received.
@@ -115,8 +116,8 @@ In the diagram above, **Consumer-B-1** and **Consumer-B-2** are able to subscrib
 
 There are two important things to be aware of when using shared mode:
 
-* Message ordering is not guaranteed.
-* You cannot use cumulative acknowledgment with shared mode.
+- Message ordering is not guaranteed.
+- You cannot use cumulative acknowledgment with shared mode.
 
 ![stream-shared-subscriptions](/img/stream-shared-subscriptions.png)
 
@@ -130,13 +131,12 @@ In the diagram above, **Consumer-C-1** is the master consumer while **Consumer-C
 
 ![stream-failover-subscriptions](/img/stream-failover-subscriptions.png)
 
-
 ## Multi-stream Subscriptions
 
 When a consumer subscribes to a GDN stream, by default it subscribes to one specific stream, such as `persistent://tenant1/fabric1/my-stream`. GDN stream consumers can simultaneously subscribe to multiple streams. You can define a list of streams in two ways:
 
-* On the basis of a [**reg**ular **ex**pression](https://en.wikipedia.org/wiki/Regular_expression) (regex), for example `persistent://tenant1/fabric1/finance-.*`
-* By explicitly defining a list of streams
+- On the basis of a [**reg**ular **ex**pression](https://en.wikipedia.org/wiki/Regular_expression) (regex), for example `persistent://tenant1/fabric1/finance-.*`
+- By explicitly defining a list of streams
 
 :::note
 When subscribing to multiple streams by regex, all streams must be in the same `geofabric`.
@@ -153,8 +153,8 @@ Message queues are essential components of many large-scale data architectures. 
 
 GDN Streams is a great choice for a message queue because:
 
-* it was built with persistent storage in mind
-* it offers automatic load balancing across consumers for messages on a stream
+- it was built with persistent storage in mind
+- it offers automatic load balancing across consumers for messages on a stream
 
 :::note
 You can use the same GDN stream to act as a real-time message bus and as a message queue if you wish (or just one or the other)
@@ -164,13 +164,13 @@ You can set aside some streams for real-time purposes and other streams for mess
 :::
 **Client configuration changes:**
 
-To use a stream as a message queue, you should distribute the receiver load on that topic across several consumers (the optimal number of consumers will depend on the load). 
+To use a stream as a message queue, you should distribute the receiver load on that topic across several consumers (the optimal number of consumers will depend on the load).
 
 Each consumer must:
 
-* Establish a [shared subscription](#shared) and use the same subscription name as the other consumers (otherwise the subscription is not shared and the consumers can't act as a processing ensemble)
+- Establish a [shared subscription](#shared) and use the same subscription name as the other consumers (otherwise the subscription is not shared and the consumers can't act as a processing ensemble)
 
-* If you'd like to have tight control over message dispatching across consumers, set the consumers' **receiver queue** size very low (potentially even to 0 if necessary).
+- If you'd like to have tight control over message dispatching across consumers, set the consumers' **receiver queue** size very low (potentially even to 0 if necessary).
 
 Each Stream has a receiver queue that determines how many messages the consumer will attempt to fetch at a time. A receiver queue of 1000 (the default), for example, means that the consumer will attempt to process 1000 messages from the stream's backlog upon connection. Setting the receiver queue to zero essentially means ensuring that each consumer is only doing one thing at a time.
 
@@ -180,13 +180,13 @@ The downside to restricting the receiver queue size of consumers is that that li
 
 By default, GDN:
 
-* immediately delete `all` messages that have been acknowledged by a consumer, and
-* persistently store all unacknowledged messages in a message backlog for upto 3 days.
+- immediately delete `all` messages that have been acknowledged by a consumer, and
+- persistently store all unacknowledged messages in a message backlog for upto 3 days.
 
 GDN streams has two features, however, that enable you to override this default behavior:
 
-* Message **retention** enables you to store messages that have been acknowledged by a consumer
-* Message **expiry** enables you to set a time to live (TTL) for messages that have not yet been acknowledged
+- Message **retention** enables you to store messages that have been acknowledged by a consumer
+- Message **expiry** enables you to set a time to live (TTL) for messages that have not yet been acknowledged
 
 :::note
 All message retention and expiry is managed at the `geofabric` level.


### PR DESCRIPTION
This PR removed "C8" from docs wherever possible. In most cases, I replaced it with "Macrometa" or "streams."

Please make sure that my replacements make sense!