### PR TITLE
Added Invite User docs

### DIFF
--- a/docs/account-management/users/invite-users.md
+++ b/docs/account-management/users/invite-users.md
@@ -3,16 +3,21 @@ sidebar_position: 20
 title: Invite Users
 ---
 
-This section describes how to invite new users to a tenant.
+This section describes how to send invitation links to email addresses so new users can access the tenant.
 
 <Tabs groupId="operating-systems">
 <TabItem value="console" label="Web Console">
 
-Follow these instructions to invite a user using the GDN console web UI.
+Follow these instructions to invite a user with the GDN console web UI.
 
 1. [Log in to your Macrometa account](https://auth.paas.macrometa.io/).
 1. Click **Account**.
 1. Click the **Invite Users** button.
+1. Type the email address to which you want to send an invitation link.
+1. (Optional) Click **Add User** to send additional invitation links, or click the gray icon to remove an email address from the list.
+1. Click **Send Invite**.
+
+
 
 
 

--- a/docs/account-management/users/invite-users.md
+++ b/docs/account-management/users/invite-users.md
@@ -7,7 +7,7 @@ This page describes how to send invitation links to email addresses so new users
 
 1. [Log in to your Macrometa account](https://auth.paas.macrometa.io/).
 1. Click **Account**.
-1. Click the **Invite Users** button.
+1. Click **Invite Users**.
 1. Type the email address to which you want to send an invitation link.
 1. (Optional) Click **Add User** to send additional invitation links, or click the gray icon to remove an email address from the list.
 1. Click **Send Invite**.

--- a/docs/account-management/users/invite-users.md
+++ b/docs/account-management/users/invite-users.md
@@ -3,7 +3,7 @@ sidebar_position: 20
 title: Invite Users
 ---
 
-This section describes how to send invitation links to email addresses so new users can access the tenant.
+This page describes how to send invitation links to email addresses so new users can access the tenant.
 
 1. [Log in to your Macrometa account](https://auth.paas.macrometa.io/).
 1. Click **Account**.

--- a/docs/account-management/users/invite-users.md
+++ b/docs/account-management/users/invite-users.md
@@ -12,4 +12,6 @@ This page describes how to send invitation links to email addresses so new users
 1. (Optional) Click **Add User** to send additional invitation links, or click the gray icon to remove an email address from the list.
 1. Click **Send Invite**.
 
+Macrometa sends an email to with a signup link to each address that you entered. Links expire after 24 hours.
+
 After sending an invitation, you can see a list of pending invitations. Click the stacked dots next to an invitation link to copy, cancel, or resend the invitation link.

--- a/docs/account-management/users/invite-users.md
+++ b/docs/account-management/users/invite-users.md
@@ -5,11 +5,6 @@ title: Invite Users
 
 This section describes how to send invitation links to email addresses so new users can access the tenant.
 
-<Tabs groupId="operating-systems">
-<TabItem value="console" label="Web Console">
-
-Follow these instructions to invite a user with the GDN console web UI.
-
 1. [Log in to your Macrometa account](https://auth.paas.macrometa.io/).
 1. Click **Account**.
 1. Click the **Invite Users** button.
@@ -17,62 +12,4 @@ Follow these instructions to invite a user with the GDN console web UI.
 1. (Optional) Click **Add User** to send additional invitation links, or click the gray icon to remove an email address from the list.
 1. Click **Send Invite**.
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-</TabItem>
-<TabItem value="apo" label="REST API">
-
-API steps
-
-</TabItem>
-<TabItem value="cli" label="CLI">
-
-CLI steps
-
-</TabItem>
-</Tabs>
-
-
-
-Follow these instructions to create a new user using the GDN console web UI.
-
-1. [Log in to your Macrometa account](https://auth.paas.macrometa.io/).
-1. Click **Account**.
-1. Click **New User**.
-1. Enter a unique username.
-1. Enter the email to be associated with this user account.
-1. Enter a password and confirm it.
-1. Optionally, choose to create the account as inactive by deselecting **Active**.
-
-## Change Password
-
-On the Users tab, you can select a user to access their details and change their password.
-
-1. [Log in to your Macrometa account](https://auth.paas.macrometa.io/).
-1. Click **Account**.
-1. Select the user whose password you want to change.
-1. Click **Edit** in the **Password** field.
-1. Enter and confirm the new password, then click **Save**.
-
-## Delete User
-
-On the Users tab, you can select a user to access their details and delete the account.
-
-1. [Log in to your Macrometa account](https://auth.paas.macrometa.io/).
-1. Click **Account**.
-1. Select the user that you want to delete.
-1. Click **Delete** and then click **Yes**.
+After sending an invitation, you can see a list of pending invitations. Click the stacked dots next to an invitation link to copy, cancel, or resend the invitation link.

--- a/docs/account-management/users/invite-users.md
+++ b/docs/account-management/users/invite-users.md
@@ -1,11 +1,47 @@
 ---
-sidebar_position: 10
-title: Create and Manage Users
+sidebar_position: 20
+title: Invite Users
 ---
 
-This section describes how to create and manage user accounts.
+This section describes how to invite new users to a tenant.
 
-## Create User
+<Tabs groupId="operating-systems">
+<TabItem value="console" label="Web Console">
+
+Follow these instructions to invite a user using the GDN console web UI.
+
+1. [Log in to your Macrometa account](https://auth.paas.macrometa.io/).
+1. Click **Account**.
+1. Click the **Invite Users** button.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</TabItem>
+<TabItem value="apo" label="REST API">
+
+API steps
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+CLI steps
+
+</TabItem>
+</Tabs>
+
+
 
 Follow these instructions to create a new user using the GDN console web UI.
 


### PR DESCRIPTION
Added documentation for the Invite User button in the Accounts screen.

Will update this to include API/CLI commands once I clarify from Eng how this works.  I suspect Invite User might be a shortcut for normal account creation, but I'm not certain.