### PR TITLE
Update "New" to "New Query"

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -73,7 +73,7 @@ When you are done experimenting with records, continue to the next step.
 Now, let's query the data you just added to your collection.
 
 1. Click **Query Workers**.
-2. Click **New** to clear the code editor.
+2. Click **New Query** to clear the code editor.
 3. Copy the code block below and paste it into the code editor.
 
   ```sql
@@ -101,7 +101,7 @@ Macrometa displays a `curl` command you can use to access this endpoint from any
 
 In the previous step, you created the `getAddresses` Query Worker, which is basically the READ in a CRUD API (Create, Read, Update, Delete). Build the rest of the API by creating a Query Worker for each of the following queries.
 
-1. In **Query Workers**, click **New**.
+1. In **Query Workers**, click **New Query**.
 1. Copy and paste a code block.
 1. Save the query using the name with each code block.
 1. Click **API Endpoint** and record the API Usage information.


### PR DESCRIPTION
This PR fixes the GUI labels for the Query Workers page so they say "New Query" instead of "New"