### PR TITLE
Fix for DOC-512

### DIFF
--- a/docs/cep/query-guide/functions/adhoc/adhoc.md
+++ b/docs/cep/query-guide/functions/adhoc/adhoc.md
@@ -29,7 +29,7 @@ CREATE SOURCE SampleAdhocQueryInputTable WITH(type = 'database', collection = "S
 CREATE WINDOW SampleAdhocQueryInputTableOneMinTimeWindow (sensorId string, temperature double) SLIDING_TIME(1 min);
 
 -- Table
-CREATE TABLE SampleAdhocQuerySensorA1234DestTable(sensorId string, temperature double);
+CREATE TABLE GLOBAL SampleAdhocQuerySensorA1234DestTable(sensorId string, temperature double);
 
 @info(name = 'Insert-to-window')
 INSERT INTO SampleAdhocQueryInputTableOneMinTimeWindow

--- a/docs/cep/reference/basics.md
+++ b/docs/cep/reference/basics.md
@@ -113,10 +113,10 @@ Provides introduction to tables and database backed stores that can be used to s
 CREATE STREAM TemperatureStream (sensorId string, temperature double);
 
 -- Defines `TemperatureLogTable` having `sensorId`, `roomNo`, and `temperature` attributes of types `string`, `string`, and `double`.
-CREATE TABLE TemperatureLogTable (sensorId string, roomNo string, temperature double);
+CREATE TABLE GLOBAL TemperatureLogTable (sensorId string, roomNo string, temperature double);
 
 -- Defines `SensorIdInfoTable` table.
-CREATE TABLE SensorIdInfoTable (sensorId string, roomNo string);
+CREATE TABLE GLOBAL SensorIdInfoTable (sensorId string, roomNo string);
 
 @info(name = 'Join-query')
 -- Selects `sensorId`, `roomNo`, and `temperature` attributes from stream and table, and adds events to `TemperatureLogTable`.

--- a/docs/cep/reference/extensions/execution/anonymizer.md
+++ b/docs/cep/reference/extensions/execution/anonymizer.md
@@ -137,9 +137,9 @@ Anonymizer uses the following syntax:
 ## Example
 
 ```js
-CREATE SOURCE patient_local WITH (type='database', collection='patient_local', replication.type="local", map.type='json') (full_name string, ssn string, email string, phone string);
+CREATE SOURCE patient_local WITH (type='database', collection='patient_local', replication.type="global", map.type='json') (full_name string, ssn string, email string, phone string);
 
-CREATE TABLE patient_public(full_name string, ssn string, email string, phone string);
+CREATE TABLE GLOBAL patient_public(full_name string, ssn string, email string, phone string);
 
 INSERT INTO patient_public
 SELECT pii:fake(full_name, "NAME_FULLNAME", true)        as full_name,

--- a/docs/cep/reference/extensions/execution/cache.md
+++ b/docs/cep/reference/extensions/execution/cache.md
@@ -35,9 +35,9 @@ CREATE TRIGGER EventsPutTrigger WITH (interval=1 sec);
 
 CREATE TRIGGER EventsGetTrigger WITH (interval=5 sec);
 
-CREATE TABLE put_in_cache(value_is_put string);
+CREATE TABLE GLOBAL put_in_cache(value_is_put string);
 
-CREATE TABLE get_from_cache(value string);
+CREATE TABLE GLOBAL get_from_cache(value string);
 
 INSERT INTO put_in_cache 
 SELECT cache:put("my_key", "my_value") as value_is_put 
@@ -53,7 +53,7 @@ Following document is saved every second in `put_in_cache`.
         {"value_is_put": "true"}
         
 		
-Following document is saved every five seconsd in `get_from_cache`.    
+Following document is saved every five seconds in `get_from_cache`.
     
         {"value": "my_value"}
 

--- a/docs/cep/reference/values-n-types.md
+++ b/docs/cep/reference/values-n-types.md
@@ -194,7 +194,7 @@ For more information refer the [Stream Query Guide](../query-guide/index.md).
 CREATE STREAM ProductInputStream (item string, price double);
 
 -- Empty `ProductInfoTable` with attributes `item` and `discount`.
-CREATE TABLE ProductInfoTable (item string, discount double);
+CREATE TABLE GLOBAL ProductInfoTable (item string, discount double);
 
 @info(name = 'Check-for-null')
 -- Checks if `price` contains `null` value.

--- a/docs/cep/tutorials/enriching-data.md
+++ b/docs/cep/tutorials/enriching-data.md
@@ -28,7 +28,7 @@ a scenario where you receive sales records generated from multiple locations as 
         
     2. Define the table as follows.
         ```sql
-        CREATE TABLE UserTable (userId long, firstName string, lastName string);
+        CREATE TABLE GLOBAL UserTable (userId long, firstName string, lastName string);
         ```
         
 3. Then define the stream query to join the stream and the table, and handle the result as required.
@@ -72,7 +72,7 @@ a scenario where you receive sales records generated from multiple locations as 
 
         CREATE STREAM TrasanctionStream (userId long, transactionAmount double, location string);
 
-        CREATE TABLE UserTable (userId long, firstName string, lastName string);
+        CREATE TABLE GLOBAL UserTable (userId long, firstName string, lastName string);
 
 		CREATE STREAM EnrichedTrasanctionStream WITH (type='stream', stream='EnrichedTrasanctionStream', map.type='json') (userId long, userName string, transactionAmount double, location string);
 
@@ -244,7 +244,7 @@ To understand how this is done, consider an example where you have some credit c
 6. To save the response of the external application, define a table named `CCInfoTable`.
 
     ```sql
-    CREATE TABLE CCInfoTable (cardNo long, cardType string);
+    CREATE TABLE GLOBAL CCInfoTable (cardNo long, cardType string);
     ```
     
 7. To save the data enriched by integrating the information received from the external service, add a stream query as follows.
@@ -270,7 +270,7 @@ To understand how this is done, consider an example where you have some credit c
 
 	CREATE STREAM EnrichedCreditCardInfoStream WITH (source.type='http-response', sink.id='cardTypeSink', map.type='xml', map.namespaces = "xmlns=http://localhost/SmartPayments/", attributes.creditCardNo = 'trp:creditCardNo',creditCardType = ".") (creditCardNo string,creditCardType string);
 
-    CREATE TABLE CCInfoTable (creditCardNo string,creditCardType string);
+    CREATE TABLE GLOBAL CCInfoTable (creditCardNo string,creditCardType string);
 
     insert into GetCreditCardInfoStream
     select creditCardNo

--- a/docs/cep/tutorials/using_rest_api.md
+++ b/docs/cep/tutorials/using_rest_api.md
@@ -61,7 +61,7 @@ STREAM_APP ="""
   -- Stream
   CREATE STREAM tutorialAppInputStream (deviceID string, roomNo int, temperature double);
   -- Table
-  CREATE TABLE tutorialAppOutputTable (id string, temperature double);
+  CREATE TABLE GLOBAL tutorialAppOutputTable (id string, temperature double);
   @info(name='Query')
   INSERT INTO tutorialAppOutputTable
   SELECT concatFn(roomNo,'-',deviceID) as id, temperature


### PR DESCRIPTION
When creating a Stream Worker, one of the parameters within the WITH clause is replication.type. The default value for this parameter is “local”, and some public doc examples use this value. However, users are experiencing issues with this replication type in the PLAY federation (https://macrometa.zendesk.com/agent/tickets/1377 for more context).
And for CREATE TABLE examples where WITH can’t be specified, I guess we have to use the keyword GLOBAL

A ticket has been raised to change this behaviour (https://macrometa.atlassian.net/browse/CEP-444); however, it will take some time for these changes to be implemented. In the meantime, we should change the documentation to have the replication type set as ‘global’.