### PR TITLE
Adding useful info

### DIFF
--- a/docs/sdks/install-sdks.md
+++ b/docs/sdks/install-sdks.md
@@ -109,5 +109,5 @@ pip install --upgrade pyC8
 ## Reference
 
 You can follow the following links for further reference regarding the SDK's:
-jsC8: [https://github.com/macrometacorp/jsC8](https://github.com/macrometacorp/jsC8)
+- jsC8: [https://github.com/macrometacorp/jsC8](https://github.com/macrometacorp/jsC8)
 pyC8: [https://github.com/Macrometacorp/pyC8](https://github.com/Macrometacorp/pyC8)

--- a/docs/sdks/install-sdks.md
+++ b/docs/sdks/install-sdks.md
@@ -64,9 +64,9 @@ To install the SDK in a notebook:
 </TabItem>
 </Tabs>
 
-## View currently installed version of the SDK
+## Check Installed SDK Version
 
-To know the currently installed version of the SDK, run the following command
+To check which version of the SDK is currently installed, run the following command in your terminal:
 
 <Tabs groupId="operating-systems">
 <TabItem value="js" label="Javascript">

--- a/docs/sdks/install-sdks.md
+++ b/docs/sdks/install-sdks.md
@@ -110,4 +110,4 @@ pip install --upgrade pyC8
 
 You can follow the following links for further reference regarding the SDK's:
 - jsC8: [https://github.com/macrometacorp/jsC8](https://github.com/macrometacorp/jsC8)
-pyC8: [https://github.com/Macrometacorp/pyC8](https://github.com/Macrometacorp/pyC8)
+- pyC8: [https://github.com/Macrometacorp/pyC8](https://github.com/Macrometacorp/pyC8)

--- a/docs/sdks/install-sdks.md
+++ b/docs/sdks/install-sdks.md
@@ -64,6 +64,27 @@ To install the SDK in a notebook:
 </TabItem>
 </Tabs>
 
+## View currently installed version of the SDK
+
+To know the currently installed version of the SDK, run the following command
+
+<Tabs groupId="operating-systems">
+<TabItem value="js" label="Javascript">
+
+```js
+npm view jsc8 version
+```
+
+</TabItem>
+<TabItem value="py" label="Python">
+
+```py
+pip show pyC8
+```
+
+</TabItem>
+</Tabs>
+
 ## Update SDKs
 
 Run the following command in your terminal to update the SDK.
@@ -84,3 +105,9 @@ pip install --upgrade pyC8
 
 </TabItem>
 </Tabs>
+
+## Reference
+
+You can follow the following links for further reference regarding the SDK's:
+jsC8: [https://www.npmjs.com/package/jsc8](https://www.npmjs.com/package/jsc8)
+pyC8: [https://pyc8.readthedocs.io/en/latest](https://pyc8.readthedocs.io/en/latest)

--- a/docs/sdks/install-sdks.md
+++ b/docs/sdks/install-sdks.md
@@ -109,5 +109,5 @@ pip install --upgrade pyC8
 ## Reference
 
 You can follow the following links for further reference regarding the SDK's:
-jsC8: [https://www.npmjs.com/package/jsc8](https://www.npmjs.com/package/jsc8)
-pyC8: [https://pyc8.readthedocs.io/en/latest](https://pyc8.readthedocs.io/en/latest)
+jsC8: [https://github.com/macrometacorp/jsC8](https://github.com/macrometacorp/jsC8)
+pyC8: [https://github.com/Macrometacorp/pyC8](https://github.com/Macrometacorp/pyC8)


### PR DESCRIPTION
I've added a way in which users can check their local version of the SDK and a couple of useful links so they can view more docs.

Maybe it would be a good idea to change the title from "Install SDKs" to "Manage SDKs" or to "Getting started with SDKs". Another option is to divide the sections into different files/web pages.