### PR TITLE
Update query worker tutorial for SQL

### DIFF
--- a/docs/queryworkers/tutorial.md
+++ b/docs/queryworkers/tutorial.md
@@ -8,53 +8,11 @@ import TabItem from '@theme/TabItem';
 
 This tutorial is about using C8QL queries as API (aka Query Workers) in Macrometa GDN with low latencies across the globe.
 
-## Installation
+## Prerequisites
 
-<Tabs groupId="operating-systems">
-<TabItem value="js" label="Javascript">
-
-```js
-With Yarn or NPM
-
-    yarn add jsc8
-    (or)
-    npm install jsc8
-
-If you want to use the SDK outside of the current directory, you can also install it globally using the `--global` flag:
-
-    npm install --global jsc8
-
-From source,
-
-    git clone https://github.com/macrometacorp/jsc8.git
-    cd jsC8
-    npm install
-    npm run dist
-```
-
-</TabItem>
-<TabItem value="py" label="Python">
-
-```py
-pyC8 requires Python 3.5+. Python 3.6 or higher is recommended
-
-To install pyC8, simply run
-
-    $ pip3 install pyC8
-
-or, if you prefer to use conda:
-
-    conda install -c conda-forge pyC8
-
-or pipenv:
-
-    pipenv install --pre pyC8
-
-Once the installation process is finished, you can begin developing applications in Python.
-```
-
-</TabItem>
-</Tabs>  
+- A [Macrometa account](https://auth-play.macrometa.io/) with admin permissions.
+- An API key with admin permissions. For more information, refer to [Create API Keys](../account-management/api-keys/create-api-keys).
+- The appropriate SDK installed. For more information, refer to [Install SDKs](../sdks/install-sdks.md).
 
 ## Code Sample
 


### PR DESCRIPTION
@dlozina-macrometa and @martin-macrometa, please review this topic and update it for SQL. Currently, it is only written for C8QL. Each example should have one tab for C8QL and one for SQL. Please remember that each tab name must be unique within the document or the build will fail.

Refer to [Task Tab Template](https://www.notion.so/macrometa/Task-tab-template-6b8daa665d234b3e8e4e9ca1290bbbac) for tab syntax.