### PR TITLE
Update Max Dispatch Throttling Rate

### DIFF
--- a/docs/references/quotas.md
+++ b/docs/references/quotas.md
@@ -41,7 +41,7 @@ The following limits apply to streams:
 | Max Subscriptions Count                       | 14    			|
 | Max Backlog Storage (MB)                      | 100   	        |
 | Max Backlog Message TTL in Minutes 			| 240 				|
-| Max Dispatch Throttling Rate (KB) 			| 4096				|
+| Max Dispatch Throttling Rate (Bytes) 			| 4096				|
 
 The following limits apply to Stream Workers:
 


### PR DESCRIPTION
I believe this is in bytes; the scale (metered) tier has a limit of 512000(512 KB) and so this should be 4 KB