### PR TITLE
add cards to streaming ml index page

### DIFF
--- a/docs/cep/query-guide/functions/streaming-ml/index.md
+++ b/docs/cep/query-guide/functions/streaming-ml/index.md
@@ -3,3 +3,11 @@ title: Streaming ML
 ---
 
 This extension provides streaming machine learning (clustering, classification, and regression) on event streams.
+<grid cols={3}>
+  <card heading="Bayesian Linear Regression" href="/cep/query-guide/functions/streaming-ml/bayesianregression" />
+  <card heading="K-Means Clustering" href="/cep/query-guide/functions/streaming-ml/kmeansincremental" />
+  <card heading="K-Means Clustering on Streaming Data" href="/cep/query-guide/functions/streaming-ml/kmeansminibatch" />
+  <card heading="Linear Binary Classification Perceptron" href="/cep/query-guide/functions/streaming-ml/perceptronclassifier" />
+  <card heading="Linear Bayesian Regression" href="/cep/query-guide/functions/streaming-ml/bayesianregression" />
+  <card heading="Linear Binary Classification Perceptron" href="/cep/query-guide/functions/streaming-ml/updateperceptronclassifier" />
+</grid>


### PR DESCRIPTION
We are sending over Stream Workers reference information to the team for a new opportunity, but the index pages in stream works that only have a description and don't reference the files in the dropdown are confusing and make it look like there is no content in the folder at first glance. 

To fix this I have added cards that link to the topics in the dropdown on the left-hand nav.