### PR TITLE
Remove extra words

### DIFF
--- a/docs/cep/sink/sink-mapping/avro.md
+++ b/docs/cep/sink/sink-mapping/avro.md
@@ -1,5 +1,5 @@
 ---
-title: avro (Sink Mapper)
+title: avro
 ---
 
 This extension is a stream worker event to Avro Message output mapper. Transports that publish messages to Avro sink can use this extension to convert stream worker events to Avro messages.

--- a/docs/cep/sink/sink-mapping/binary.md
+++ b/docs/cep/sink/sink-mapping/binary.md
@@ -1,5 +1,5 @@
 ---
-title: binary (Sink Mapper)
+title: binary
 ---
 
 This section explains how to map events processed via stream worker in order to publish them in the `binary` format.
@@ -11,6 +11,5 @@ This section explains how to map events processed via stream worker in order to 
 ## Example 1
 
     CREATE SINK FooStream WITH (type='stream', topic='gdn', map.type='binary') (symbol string, price float, volume long);
-
 
 This will publish stream worker event in binary format.

--- a/docs/cep/sink/sink-mapping/csv.md
+++ b/docs/cep/sink/sink-mapping/csv.md
@@ -1,5 +1,5 @@
 ---
-title: csv (Sink Mapper)
+title: csv
 ---
 
 This output mapper extension allows you to convert stream worker events processed by the GDN stream processor to CSV message before publishing them. You can either use custom placeholder to map a custom CSV message or use predefined CSV format where event conversion takes place without extra configurations.

--- a/docs/cep/sink/sink-mapping/json.md
+++ b/docs/cep/sink/sink-mapping/json.md
@@ -1,5 +1,5 @@
 ---
-title: json (Sink Mapper)
+title: json
 ---
 
 This extension is an Event to JSON output mapper. Transports that publish messages can utilize this extension to convert Stream App events to JSON messages. You can either send a pre-defined JSON format or a custom JSON message.

--- a/docs/cep/sink/sink-mapping/keyvalue.md
+++ b/docs/cep/sink/sink-mapping/keyvalue.md
@@ -1,5 +1,5 @@
 ---
-title: key-value (Sink Mapper)
+title: keyvalue
 ---
 
 The `Event to Key-Value Map` output mapper extension allows you to convert Stream App events processed by gdn SP to key-value map events before publishing them. You can either use pre-defined keys where conversion takes place without extra configurations, or use custom keys with which the messages can be published.

--- a/docs/cep/sink/sink-mapping/passThrough.md
+++ b/docs/cep/sink/sink-mapping/passThrough.md
@@ -1,5 +1,5 @@
 ---
-title: passThrough (Sink Mapper)
+title: passThrough
 ---
 
 Pass-through mapper passed events (Event\[\]) through without any mapping or modifications.

--- a/docs/cep/sink/sink-mapping/protobuf.md
+++ b/docs/cep/sink/sink-mapping/protobuf.md
@@ -1,5 +1,5 @@
 ---
-title: protobuf (Sink Mapper)
+title: protobuf
 ---
 
 This output mapper allows you to convert Events to protobuf messages before publishing them. To work with this mapper you have to add auto-generated protobuf classes to the project classpath. When you use this output mapper, you can either define stream attributes as the same names as the protobuf message attributes or you can use custom mapping to map stream definition attributes with the protobuf attributes. When you use this mapper with `stream processor-io-grpc` you don't have to provide the protobuf message class in the `class` parameter.

--- a/docs/cep/sink/sink-mapping/text.md
+++ b/docs/cep/sink/sink-mapping/text.md
@@ -1,5 +1,5 @@
 ---
-title: text (Sink Mapper)
+title: text
 ---
 
 This extension is an Event to Text output mapper. Transports that publish

--- a/docs/cep/sink/sink-mapping/text.md
+++ b/docs/cep/sink/sink-mapping/text.md
@@ -8,8 +8,7 @@ text messages. Users can use a predefined text format where event
 conversion is carried out without any additional configurations, or use
 custom placeholder(using `{{` and `}}`) to map custom text messages.
 
-You can also enable mustache based custom mapping. In mustache-based custom mapping, you can use custom placeholder (using `{{` and `}}`
-or `{{{` and `}}}`) to map custom text. In mustache-based custom
+You can also enable mustache based custom mapping. In mustache-based custom mapping, you can use custom placeholder (using `{{` and `}}` or `{{{` and `}}}`) to map custom text. In mustache-based custom
 mapping, all variables are HTML escaped by default. For example: `&` is
 replaced with `&amp;` `"` is replaced with `&quot;` `=` is replaced with
 `&#61;` If you want to return unescaped HTML, use the triple mustache

--- a/docs/cep/sink/sink-types/gcp-pubsub.md
+++ b/docs/cep/sink/sink-types/gcp-pubsub.md
@@ -1,5 +1,5 @@
 ---
-title: Google Pub-Sub (Sink)
+title: Google Pub-Sub
 ---
 
 The Google PubSub sink publishes messages to a topic in the Google PubSub server. If the required topic does not exist, Google PubSub Sink creates the topic and publishes messages to it.

--- a/docs/cep/sink/sink-types/http-call.md
+++ b/docs/cep/sink/sink-types/http-call.md
@@ -1,5 +1,5 @@
 ---
-title: http-call (Sink)
+title: http-call
 ---
 
 The http-call sink publishes messages to endpoints via HTTP or HTTPS protocols using methods such as POST, GET, PUT, and DELETE on formats `text` or `JSON` and consume responses through its corresponding http-call-response source. It also supports calling endpoints protected with basic authentication or OAuth 2.0.

--- a/docs/cep/sink/sink-types/http-service-response.md
+++ b/docs/cep/sink/sink-types/http-service-response.md
@@ -1,5 +1,5 @@
 ---
-title: http-service-response (Sink)
+title: http-service-response
 ---
 
 The http-service-response sink send responses of the requests consumed by its corresponding http-service source, by mapping the response messages to formats such as `text` and `JSON`.

--- a/docs/cep/sink/sink-types/http.md
+++ b/docs/cep/sink/sink-types/http.md
@@ -1,5 +1,5 @@
 ---
-title: http (Sink)
+title: http
 ---
 
 HTTP sink publishes messages via HTTP or HTTPS protocols using methods such as POST, GET, PUT, and DELETE on formats `text` and `JSON`. It can also publish to endpoints protected by basic authentication or OAuth 2.0.

--- a/docs/cep/sink/sink-types/jms.md
+++ b/docs/cep/sink/sink-types/jms.md
@@ -1,5 +1,5 @@
 ---
-title: jms (Sink)
+title: jms
 ---
 
 JMS sink allows users to subscribe to a JMS broker and publish JMS messages.

--- a/docs/cep/sink/sink-types/kafka.md
+++ b/docs/cep/sink/sink-types/kafka.md
@@ -1,5 +1,5 @@
 ---
-title: kafka (Sink)
+title: kafka
 ---
 
 A Kafka sink publishes events processed by GDN stream worker to a topic with a partition for a Kafka cluster.If the topic is not already created in the Kafka cluster, the Kafka sink creates the default partition for the given topic. The publishing topic and partition can be a dynamic value taken from the GDN stream worker event.

--- a/docs/cep/sink/sink-types/kafkaMultiDC.md
+++ b/docs/cep/sink/sink-types/kafkaMultiDC.md
@@ -1,5 +1,5 @@
 ---
-title: kafkaMultiDC (Sink)
+title: kafkaMultiDC
 ---
 
 A Kafka sink publishes events processed by gdn SP to a topic with a partition for a Kafka cluster. The events can be published in the `TEXT`, `JSON` or `Binary` format. If the topic is not already created in the Kafka cluster, the Kafka sink creates the default partition for the given topic. The publishing topic and partition can be a dynamic value taken from the stream worker event. To configure a sink to publish events via the Kafka transport, and using two Kafka brokers to publish events to the same topic, the `type` parameter must have `kafkaMultiDC` as its value.

--- a/docs/cep/sink/sink-types/log.md
+++ b/docs/cep/sink/sink-types/log.md
@@ -1,5 +1,5 @@
 ---
-title: log (Sink)
+title: log
 ---
 
 This is a sink that can be used as a logger. This will log the output events in the output stream with user specified priority and a prefix.

--- a/docs/cep/sink/sink-types/mqtt.md
+++ b/docs/cep/sink/sink-types/mqtt.md
@@ -1,5 +1,5 @@
 ---
-title: MQTT Sink
+title: MQTT
 ---
 
 The MQTT sink publishes messages to a topic in the MQTT server. If the required topic does not exist, then the MQTT sink creates the topic and publishes messages to it.

--- a/docs/cep/sink/sink-types/prometheus.md
+++ b/docs/cep/sink/sink-types/prometheus.md
@@ -1,5 +1,5 @@
 ---
-title: prometheus (Sink)
+title: prometheus
 ---
 
 This sink publishes events processed by stream worker into Prometheus metrics and exposes them to the Prometheus server at the specified URL. The created metrics can be published to Prometheus via `server` or `pushGateway`, depending on your preference. The metric types that are supported by the Prometheus sink are `counter`, `gauge`, `histogram`, and `summary`. The values and labels of the Prometheus metrics can be updated through the events.

--- a/docs/cep/sink/sink-types/s3.md
+++ b/docs/cep/sink/sink-types/s3.md
@@ -1,5 +1,5 @@
 ---
-title: s3 (Sink)
+title: s3
 ---
 
 S3 sink publishes events as Amazon AWS S3 buckets.

--- a/docs/cep/sink/sink-types/sse.md
+++ b/docs/cep/sink/sink-types/sse.md
@@ -1,5 +1,5 @@
 ---
-title: SSE Sink
+title: SSE
 ---
 
 HTTP SSE sink sends events to all subscribers.

--- a/docs/cep/sink/sink-types/tcp.md
+++ b/docs/cep/sink/sink-types/tcp.md
@@ -1,5 +1,5 @@
 ---
-title: tcp (Sink)
+title: tcp
 ---
 
 A stream worker application can be configured to publish events via the TCP transport by adding the `type='tcp'` annotation at the top of an event stream definition.

--- a/docs/cep/source/source-mapping/avro.md
+++ b/docs/cep/source/source-mapping/avro.md
@@ -1,9 +1,8 @@
 ---
-title: avro (Source Mapper)
+title: avro
 ---
 
-This extension is an Avro to Event input mapper. Transports that accept Avro messages can use this extension to convert the incoming Avro
-messages to stream worker events. The Avro schema to be used for creating Avro messages can be specified as a parameter in the stream definition.
+This extension is an Avro to Event input mapper. Transports that accept Avro messages can use this extension to convert the incoming Avro messages to stream worker events. The Avro schema to be used for creating Avro messages can be specified as a parameter in the stream definition.
 
 If no Avro schema is specified, a flat Avro schema of the `record` type is generated with the stream attributes as schema fields. The generated/specified Avro schema is used to convert Avro messages to stream worker events.
 

--- a/docs/cep/source/source-mapping/binary.md
+++ b/docs/cep/source/source-mapping/binary.md
@@ -1,5 +1,5 @@
 ---
-title: binary (Source Mapper)
+title: binary
 ---
 
 This extension is a binary input mapper that converts events received in `binary` format to stream worker events before they are processed.

--- a/docs/cep/source/source-mapping/csv.md
+++ b/docs/cep/source/source-mapping/csv.md
@@ -1,5 +1,5 @@
 ---
-title: csv (Source Mapper)
+title: csv
 ---
 
 This extension is used to convert a CSV message to stream worker event input mapper. You can either receive a predefined CSV message where event conversion takes place without extra configurations or receive custom CSV message where a custom place order maps from a custom CSV message.

--- a/docs/cep/source/source-mapping/keyvalue.md
+++ b/docs/cep/source/source-mapping/keyvalue.md
@@ -1,5 +1,5 @@
 ---
-title: keyvalue (Source Mapper)
+title: keyvalue
 ---
 
 `Key-Value Map to Event` input mapper extension allows transports that accept events as key value maps to convert those events to stream worker events. You can either receive predefined keys where conversion takes place without extra configurations, or use custom keys to map from the message.

--- a/docs/cep/source/source-mapping/passThrough.md
+++ b/docs/cep/source/source-mapping/passThrough.md
@@ -1,5 +1,5 @@
 ---
-title: passThrough (Source Mapper)
+title: passThrough
 ---
 
 This input mapper allows you to convert protobuf messages into Events.

--- a/docs/cep/source/source-mapping/text.md
+++ b/docs/cep/source/source-mapping/text.md
@@ -1,5 +1,5 @@
 ---
-title: text (Source Mapper)
+title: text
 ---
 
 This extension is a text to stream worker event input mapper. Transports that accept text messages can use this extension to convert the incoming text message to a stream worker event. Users can either use a predefined text format where event conversion happens without any additional configurations, or specify a regex to map a text message using custom configurations.

--- a/docs/cep/source/source-types/gcp-pubsub.md
+++ b/docs/cep/source/source-types/gcp-pubsub.md
@@ -1,5 +1,5 @@
 ---
-title: Google Pubsub (Source)
+title: Google Pubsub
 ---
 
 The Google PubSub source receives events to be processed by Macrometa from a topic in a Google PubSub server. Here, a subscriber client creates a subscription to that topic and consumes messages via the subscription. The subscription applications receive only the messages that are published after the subscription is created.

--- a/docs/cep/source/source-types/http-call-response.md
+++ b/docs/cep/source/source-types/http-call-response.md
@@ -1,5 +1,5 @@
 ---
-title: http-call-response (Source)
+title: http-call-response
 ---
 
 The http-call-response source receives the responses for the calls made by its corresponding http-call sink, and maps them from formats such as `text` and `JSON`.

--- a/docs/cep/source/source-types/http-service.md
+++ b/docs/cep/source/source-types/http-service.md
@@ -1,9 +1,8 @@
 ---
-title: http-service (Source)
+title: http-service
 ---
 
-The http-service source receives POST requests via HTTP and HTTPS protocols in format such as `text` and `JSON` and sends responses
-via its corresponding http-service-response sink correlated through a unique `source.id`.
+The http-service source receives POST requests via HTTP and HTTPS protocols in format such as `text` and `JSON` and sends responses via its corresponding http-service-response sink correlated through a unique `source.id`.
 
 For request and response correlation, it generates a `messageId` upon each incoming request and expose it via transport
 properties in the format `trp:messageId` to correlate them with the responses at the http-service-response sink.

--- a/docs/cep/source/source-types/http.md
+++ b/docs/cep/source/source-types/http.md
@@ -1,5 +1,5 @@
 ---
-title: http (Source)
+title: http
 ---
 
 HTTP source receives POST requests via HTTP and HTTPS protocols in format such as `text` and `JSON`. It also supports basic

--- a/docs/cep/source/source-types/kafka.md
+++ b/docs/cep/source/source-types/kafka.md
@@ -1,12 +1,8 @@
 ---
-title: kafka (Source)
+title: kafka
 ---
 
-A Kafka source receives events to be processed by GDP stream workers from a topic
-with a partition for a Kafka cluster. The events received can be in the
-`TEXT`, `JSON`, or `Binary` format. If the topic is not already
-created in the Kafka cluster, the Kafka sink creates the default
-partition for the given topic.
+A Kafka source receives events to be processed by GDP stream workers from a topic with a partition for a Kafka cluster. The events received can be in the `TEXT`, `JSON`, or `Binary` format. If the topic is not already created in the Kafka cluster, the Kafka sink creates the default partition for the given topic.
 
 ## Syntax
 

--- a/docs/cep/source/source-types/kafkaMultiDC.md
+++ b/docs/cep/source/source-types/kafkaMultiDC.md
@@ -1,12 +1,12 @@
 ---
-title: kafkaMultiDC (Source)
+title: kafkaMultiDC
 ---
 
 The Kafka Multi-Datacenter(DC) source receives records from the same
 topic in brokers deployed in two different kafka clusters. It filters
 out all the duplicate messages and ensures that the events are received
 in the correct order using sequential numbering. It receives events in
-formats such as `TEXT`, `JSON`, and `Binary`.The Kafka Source
+formats such as `TEXT`, `JSON`, and `Binary`. The Kafka Source
 creates the default partition `0` for a given topic, if the topic has
 not yet been created in the Kafka cluster.
 

--- a/docs/cep/source/source-types/mqtt.md
+++ b/docs/cep/source/source-types/mqtt.md
@@ -1,5 +1,5 @@
 ---
-title: MQTT Source
+title: MQTT
 ---
 
 The MQTT source receives events to be processed by Macrometa from a topic in the MQTT server.

--- a/docs/cep/source/source-types/prometheus.md
+++ b/docs/cep/source/source-types/prometheus.md
@@ -1,5 +1,5 @@
 ---
-title: prometheus (Source)
+title: prometheus
 ---
 
 This source consumes Prometheus metrics that are exported from a specified URL as stream worker events by sending HTTP requests to the URL.

--- a/docs/cep/source/source-types/sse.md
+++ b/docs/cep/source/source-types/sse.md
@@ -1,5 +1,5 @@
 ---
-title: SSE Source
+title: SSE
 ---
 
 HTTP SSE source sends a request to a given URL and listens to the response stream.

--- a/docs/cep/source/source-types/tcp.md
+++ b/docs/cep/source/source-types/tcp.md
@@ -1,10 +1,8 @@
 ---
-title: tcp (Source)
+title: tcp
 ---
 
-A stream worker application can be configured to receive events via the TCP transport by adding the `type='tcp'` annotation at the top
-of an event stream definition. When this is defined the associated stream will receive events from the TCP transport on the host and port
-defined in the system.
+A stream worker application can be configured to receive events via the TCP transport by adding the `type='tcp'` annotation at the top of an event stream definition. When this is defined the associated stream will receive events from the TCP transport on the host and port defined in the system.
 
 ## Syntax
 


### PR DESCRIPTION
I realized that having the descriptor in the title in parentheses not only looked odd, it was superfluous now that the topics are in proper folders. Adding @dustinlarimer to this PR in case he wants to disagree.

- Removed redundant words from titles.
- Some minor format edits.
- No meaningful content changes.