### PR TITLE
Add Vercel Analytics, fix meta tags

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -63,24 +63,7 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       image: 'img/macrometa-preview-dark.png',
-      metadata: [
-        {
-          name: 'og:title',
-          content: 'Macrometa Docs'
-        },
-        {
-          name: 'og:description',
-          content: 'Powering the next generation of apps and APIs. Store, process, and serve data within milliseconds of everyone on the planet.'
-        },
-        {
-          name: 'og:url',
-          content: `${host}/docs/`
-        },
-        {
-          name: 'og:image',
-          content: `${host}/img/macrometa-preview-dark.png`
-        }
-      ],
+      metadata: [],
       algolia: {
         appId: 'GHXKYI4VEC', // public + read only and safe to commit
         apiKey: '91737ee0cdeab53f4cc7a1c650eee730', // public + read only and safe to commit

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@mdx-js/react": "^1.6.21",
     "@stoplight/elements": "7.6.3",
     "@types/react": "^17.0.1",
+    "@vercel/analytics": "^0.1.8",
     "clsx": "^1.1.1",
     "dotenv": "^16.0.0",
     "posthog-docusaurus": "^1.0.3",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -12,27 +12,17 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 // import styles from './index.module.css';
 
 /* Fonts */
-import '@fontsource/source-code-pro'
+import '@fontsource/source-code-pro';
 
 export default function Homepage() {
   const { siteConfig } = useDocusaurusContext();
   return (
     <Layout>
       <Head>
-        <meta title="Macrometa Docs" />
-        <meta property="og:title" content="Macrometa Docs" />
-        <meta property="og:url" content="https://www.macrometa.com/docs" />
-        <meta property="og:image" content="https://www.macrometa.com/docs/assets/images/map.png" />
-        <meta
-          property="og:description"
-          description="Powering the next generation of apps and APIs. Build performant apps on the edge with our lightning-fast, stateful serverless global data platform"
-        />
-        <link rel="canonical" href="https://www.macrometa.com/docs" />
         <link rel="preload" href="https://fonts.macrometa.com/averta/averta-cyrillic-regular.woff2" as="font" crossorigin />
         <link rel="preload" href="https://fonts.macrometa.com/averta/averta-cyrillic-semibold.woff2" as="font" crossorigin />
       </Head>
       <Redirect to={`${siteConfig.baseUrl}quickstart`} />
-
       {/* <div className={styles.heroBanner}>
         <h1>
           Documentation

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { inject } from '@vercel/analytics';
+
+export default function Root({ children }) {
+  inject();
+  return (
+    <>{children}</>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3830,6 +3830,11 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
+"@vercel/analytics@^0.1.8":
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-0.1.8.tgz#71f1f8c7bb98ac0c5c47eb3fb8ccbe8141b9fe47"
+  integrity sha512-PQrOI8BJ9qUiVJuQfnKiJd15eDjDJH9TBKsNeMrtelT4NAk7d9mBVz1CoZkvoFnHQ0OW7Xnqmr1F2nScfAnznQ==
+
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz"


### PR DESCRIPTION
This PR adds Vercel Analytics. This also fixes our meta tags, so that relevant page information will actually show up instead of static values.