### PR TITLE
DOC-598 - Document Naming Requirement

### DIFF
--- a/docs/cep/stream-worker-basics/index.md
+++ b/docs/cep/stream-worker-basics/index.md
@@ -9,8 +9,14 @@ If you are new to stream workers, this section explains in basic terms what stre
 
 If you haven't already, check out [Getting Started with Stream Workers](../getting-started-stream-workers.md) for a quick introduction.
 
-:::note
+## Unique Name Requirements
+
+All the elements such as streams, tables, triggers, functions, window, sink, sources, query workers, and indexes must be defined with unique names.
+
+For example, If you want to create two separate indexes with the same name in for different tables, the stream workers will not allow it, informing you that there’s another index element with the same name.
+
+## Best Practices
+
 Best practice is to keep stream worker functionality limited to one business use case per stream worker. Additionally, stream workers can use shared sinks and sources to reduce code duplication and improve maintainability.
-:::
 
 <DocCardList />


### PR DESCRIPTION
Document the limitation noted in Query Language Enhancements regarding the language not allowing elements to have the same name.