### PR TITLE
Search Views CLI update

### DIFF
--- a/docs/cli/search-views-cli.md
+++ b/docs/cli/search-views-cli.md
@@ -51,7 +51,7 @@ gdnsl view create <view-name> [flags]
   # Create test view with include-all-fields:
   gdnsl view create test --collection demo --include-all-fields
 
-  # Create test view primary sort field:
+  # Create test view with primary sort field:
   gdnsl view create test --collection demo --field "name:text_en,text_fr" --field "age:text_en" --primary-sort-field "name:asc"
 
 ```

--- a/docs/cli/search-views-cli.md
+++ b/docs/cli/search-views-cli.md
@@ -70,7 +70,7 @@ gdnsl view create <view-name> [flags]
       --include-all-fields boolean    if true, index all fields on a particular level of depth (default: false).
       --fabric                 Name of the fabric to use.
       --primary-sort-field string  Sort by a value in a specific order <fieldName:direction>
-                              Example: "name:asc>"
+                              Example: "name:asc" or "name:desc".
 ```
 
 **Options inherited:**

--- a/docs/cli/search-views-cli.md
+++ b/docs/cli/search-views-cli.md
@@ -33,23 +33,26 @@ gdnsl view create <view-name> [flags]
 **Examples:**
 
 ```bash
-  # Create test view on demo collection
+  # Create test view on demo collection:
   gdnsl view create test --collection demo
 
-  # Create test view on demo collection with analyzer
+  # Create test view with analyzer:
   gdnsl view create test --collection demo --analyzer identity
 
-  # Create test view on demo collection with fields
+  # Create test view with fields:
   gdnsl view update test --collection demo --field "name:text_en,text_fr" --field "age:text_en"
   
-  # Create test view on demo collection with store-values
+  # Create test view with store-values:
   gdnsl view create test --collection demo --store-values none
 
-  # Create test view on demo collection with track-list-positions
+  # Create test view with track-list-positions:
   gdnsl view create test --collection demo --track-list-positions
 
-  # Create test view on demo collection with include-all-fields
+  # Create test view with include-all-fields:
   gdnsl view create test --collection demo --include-all-fields
+
+  # Create test view primary sort field:
+  gdnsl view create test --collection demo --field "name:text_en,text_fr" --field "age:text_en" --primary-sort-field "name:asc"
 
 ```
 
@@ -63,9 +66,11 @@ gdnsl view create <view-name> [flags]
       --store-values string    How should the view track the attribute values, this setting allows for additional value retrieval optimizations, one of:
                                none: Do not store values by the view.
                                id: Store only information about value presence, to allow use of the EXISTS() function (default "none").
-      --track-list-positions boolean  The flag determines whether or not values in a lists should be treated separate (default: false).
-      --include-all-fields boolean    The flag determines whether or not to index all fields on a particular level of depth (default: false).
+      --track-list-positions boolean  If true, values in a lists should be treated separate (default: false).
+      --include-all-fields boolean    if true, index all fields on a particular level of depth (default: false).
       --fabric                 Name of the fabric to use.
+      --primary-sort-field string  Sort by a value in a specific order <fieldName:direction>
+                              Example: "name:asc>"
 ```
 
 **Options inherited:**


### PR DESCRIPTION
This PR adds `primary-sort-field` to the CLI instructions for Search Views.

This section still needs a lot of work for formatting and concision, but those will come in another PR.