### PR TITLE
Search CRUD topics - part 2

### DIFF
--- a/docs/search/views/create-search-views-nested.md
+++ b/docs/search/views/create-search-views-nested.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 30
+sidebar_position: 25
 title: Search View with Nested Fields
 ---
 

--- a/docs/search/views/delete-search-view.md
+++ b/docs/search/views/delete-search-view.md
@@ -36,8 +36,30 @@ Use our command line interface to [Delete a Search View](../../CLI/search-views-
 <TabItem value="py" label="Python SDK">
 
 ```py
+# Import libraries
+from c8 import C8Client
 
+# Define constants
+URL = "play.paas.macrometa.io"
+GEO_FABRIC = "_system"
+API_KEY = "<API Key>" # Change this to your API key.
+SEARCH_VIEW_NAME = "example_search_view"
 
+# Authenticate with API key.
+client = C8Client(protocol='https', host=URL, port=443, apikey=API_KEY, geofabric=GEO_FABRIC)
+print("Connected to GDN.")
+
+# Check if search view exists
+list_views = client.list_all_views()
+if any(view.get('name') == SEARCH_VIEW_NAME for view in list_views):
+    # Delete the search view if it exists
+    response = client.delete_view(SEARCH_VIEW_NAME)
+    if response is True:
+        print(f"Successfully deleted search view: {SEARCH_VIEW_NAME}.")
+    else:
+        print("Error deleting search view.")
+else:
+    print(f"Search view {SEARCH_VIEW_NAME} does not exist.")
 ```
 
 </TabItem>

--- a/docs/search/views/delete-search-view.md
+++ b/docs/search/views/delete-search-view.md
@@ -80,7 +80,7 @@ async function deleteMySearchView() {
     console.log(`Search view "${searchViewName}" does not exist`);
     return;
   }
-  await client.deleteView(view.id);
+  await client.deleteView(view.name);
   console.log(`Successfully deleted search view: ${searchViewName}`);
 }
 

--- a/docs/search/views/delete-search-view.md
+++ b/docs/search/views/delete-search-view.md
@@ -1,0 +1,52 @@
+---
+sidebar_position: 40
+title: Delete a Search View
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+This page explains how to delete a search view.
+
+## Delete Search View
+
+<Tabs groupId="operating-systems">
+<TabItem value="console" label="Web Console">
+
+Follow these instructions to delete a search view using the GDN console web UI.
+
+1. [Log in to your Macrometa account](https://auth-play.macrometa.io/).
+1. Click **Data > Search Views**.
+1. Click **Delete** next to the search view that you want to delete.
+1. Click **Yes** to confirm.
+
+</TabItem>
+<TabItem value="api" label="REST API">
+
+Use our interactive API Reference with code generation in 18 programming languages to [Delete a Search View](https://www.macrometa.com/docs/api#/operations/deleteView).
+
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+Use our command line interface to [Delete a Search View](../../CLI/search-views-cli#gdnsl-view-delete).
+
+
+</TabItem>
+<TabItem value="py" label="Python SDK">
+
+```py
+
+
+```
+
+</TabItem>
+<TabItem value="js" label="JavaScript SDK">
+
+```js
+
+
+```
+
+</TabItem>
+</Tabs>

--- a/docs/search/views/delete-search-view.md
+++ b/docs/search/views/delete-search-view.md
@@ -66,6 +66,25 @@ else:
 <TabItem value="js" label="JavaScript SDK">
 
 ```js
+// Connect to GDN.
+const jsc8 = require("jsc8");
+const client = new jsc8({url: "https://play.paas.macrometa.io", apiKey: "<API Key>", fabricName: "_system"});
+console.log("Connected to GDN.");
+
+const searchViewName = "Search"; // Replace with the name of the search view you want to delete.
+
+async function deleteMySearchView() {
+  const listOfViews = await client.getListOfViews();
+  const view = listOfViews.result.find(v => v.name === searchViewName);
+  if (!view) {
+    console.log(`Search view "${searchViewName}" does not exist`);
+    return;
+  }
+  await client.deleteView(view.id);
+  console.log(`Successfully deleted search view: ${searchViewName}`);
+}
+
+deleteMySearchView();
 
 
 ```

--- a/docs/search/views/integration.md
+++ b/docs/search/views/integration.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 40
+sidebar_position: 80
 title: Integration
 ---
 

--- a/docs/search/views/optional-properties.md
+++ b/docs/search/views/optional-properties.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 60
+sidebar_position: 100
 title: Optional Properties
 ---
 

--- a/docs/search/views/primary-sort-order.md
+++ b/docs/search/views/primary-sort-order.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 50
+sidebar_position: 90
 title: Primary Sort Order
 ---
 

--- a/docs/search/views/rename-search-view.md
+++ b/docs/search/views/rename-search-view.md
@@ -68,7 +68,7 @@ else:
 ```js
 // Connect to GDN.
 const jsc8 = require("jsc8");
-const client = new jsc8({url: "https://play.paas.macrometa.io", apiKey: "TD0IqyKNnQaq5F88bRg0GAg.james_test2.CnC1oHcyDucQRJdoK0EoalovMDGAV1LqWjxI0dPO7PlLfyXza3dq9PfT3CIXEFz4d60ced", fabricName: "_system"});
+const client = new jsc8({url: "https://play.paas.macrometa.io", apiKey: "<API Key>", fabricName: "_system"});
 console.log("Connected to GDN.");
 
 const searchViewName = "SearchView"; // Replace with the name of the search view you want to rename.

--- a/docs/search/views/rename-search-view.md
+++ b/docs/search/views/rename-search-view.md
@@ -82,7 +82,7 @@ async function renameMySearchView () {
     return;
   }
   const renamedView = await client.renameView(view.id, newSearchViewName);
-  console.log(`Successfully renamed search view: ${renamedView.name}`);
+  console.log(`Successfully renamed search view: ${renamedView.result.name}`);
 }
 
 renameMySearchView();

--- a/docs/search/views/rename-search-view.md
+++ b/docs/search/views/rename-search-view.md
@@ -1,0 +1,53 @@
+---
+sidebar_position: 30
+title: Rename a Search View
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+This page explains how to rename a search view.
+
+## Rename Search View
+
+<Tabs groupId="operating-systems">
+<TabItem value="console" label="Web Console">
+
+Follow these instructions to rename a search view using the GDN console web UI.
+
+1. [Log in to your Macrometa account](https://auth-play.macrometa.io/).
+1. Click **Data > Search Views**.
+1. Click **Rename** next to the search view for which you want to change the name.
+1. Enter a new name in the field and click **Rename**.
+1. Click **Yes** to confirm.
+
+</TabItem>
+<TabItem value="api" label="REST API">
+
+Use our interactive API Reference with code generation in 18 programming languages to [Rename a Search View](https://www.macrometa.com/docs/api#/operations/modifyView:rename).
+
+
+</TabItem>
+<TabItem value="cli" label="CLI">
+
+Use our command line interface to [Rename a Search View](../../CLI/search-views-cli#gdnsl-view-rename).
+
+
+</TabItem>
+<TabItem value="py" label="Python SDK">
+
+```py
+
+
+```
+
+</TabItem>
+<TabItem value="js" label="JavaScript SDK">
+
+```js
+
+
+```
+
+</TabItem>
+</Tabs>

--- a/docs/search/views/rename-search-view.md
+++ b/docs/search/views/rename-search-view.md
@@ -45,7 +45,7 @@ URL = "play.paas.macrometa.io"
 GEO_FABRIC = "_system"
 API_KEY = "<API Key>" # Change this to your API key.
 SEARCH_VIEW_NAME = "SearchView" # Change this to the search view you want to rename.
-NEW_SEARCH_VIEW_NAME = "SearchView2" # Change this to the new name for the search view.
+NEW_SEARCH_VIEW_NAME = "NewSearchView" # Change this to the new name for the search view.
 
 # Authenticate with API key.
 client = C8Client(protocol='https', host=URL, port=443, apikey=API_KEY, geofabric=GEO_FABRIC)
@@ -66,6 +66,26 @@ else:
 <TabItem value="js" label="JavaScript SDK">
 
 ```js
+// Connect to GDN.
+const jsc8 = require("jsc8");
+const client = new jsc8({url: "https://play.paas.macrometa.io", apiKey: "TD0IqyKNnQaq5F88bRg0GAg.james_test2.CnC1oHcyDucQRJdoK0EoalovMDGAV1LqWjxI0dPO7PlLfyXza3dq9PfT3CIXEFz4d60ced", fabricName: "_system"});
+console.log("Connected to GDN.");
+
+const searchViewName = "SearchView"; // Replace with the name of the search view you want to rename.
+const newSearchViewName = "NewSearchView"; // Replace with the new name for the search view.
+
+async function renameMySearchView () {
+  const listOfViews = await client.getListOfViews();
+  const view = listOfViews.result.find(v => v.name === searchViewName);
+  if (!view) {
+    console.log(`Search view "${searchViewName}" does not exist`);
+    return;
+  }
+  const renamedView = await client.renameView(view.id, newSearchViewName);
+  console.log(`Successfully renamed search view: ${renamedView.name}`);
+}
+
+renameMySearchView();
 
 
 ```

--- a/docs/search/views/rename-search-view.md
+++ b/docs/search/views/rename-search-view.md
@@ -37,6 +37,27 @@ Use our command line interface to [Rename a Search View](../../CLI/search-views-
 <TabItem value="py" label="Python SDK">
 
 ```py
+# Import libraries
+from c8 import C8Client
+
+# Define constants
+URL = "play.paas.macrometa.io"
+GEO_FABRIC = "_system"
+API_KEY = "<API Key>" # Change this to your API key.
+SEARCH_VIEW_NAME = "SearchView" # Change this to the search view you want to rename.
+NEW_SEARCH_VIEW_NAME = "SearchView2" # Change this to the new name for the search view.
+
+# Authenticate with API key.
+client = C8Client(protocol='https', host=URL, port=443, apikey=API_KEY, geofabric=GEO_FABRIC)
+
+# Check if search view exists
+list_views = client.list_all_views()
+if any(view.get('name') == SEARCH_VIEW_NAME for view in list_views):
+    # Rename the search view if it exists
+    response = client.rename_view(SEARCH_VIEW_NAME, NEW_SEARCH_VIEW_NAME)
+    print(f"Successfully renamed search view from '{SEARCH_VIEW_NAME}' to '{NEW_SEARCH_VIEW_NAME}'.")
+else:
+    print(f"Search view '{SEARCH_VIEW_NAME}' does not exist.")
 
 
 ```

--- a/docs/search/views/rename-search-view.md
+++ b/docs/search/views/rename-search-view.md
@@ -81,7 +81,7 @@ async function renameMySearchView () {
     console.log(`Search view "${searchViewName}" does not exist`);
     return;
   }
-  const renamedView = await client.renameView(view.id, newSearchViewName);
+  const renamedView = await client.renameView(view.name, newSearchViewName);
   console.log(`Successfully renamed search view: ${renamedView.result.name}`);
 }
 

--- a/docs/search/views/rename-search-view.md
+++ b/docs/search/views/rename-search-view.md
@@ -87,7 +87,6 @@ async function renameMySearchView () {
 
 renameMySearchView();
 
-
 ```
 
 </TabItem>

--- a/docs/search/views/rename-search-view.md
+++ b/docs/search/views/rename-search-view.md
@@ -81,7 +81,7 @@ async function renameMySearchView () {
     console.log(`Search view "${searchViewName}" does not exist`);
     return;
   }
-  const renamedView = await client.renameView(view.id, newSearchViewName);
+  const renamedView = await client.renameView(view.name, newSearchViewName);
   console.log(`Successfully renamed search view: ${renamedView.name}`);
 }
 


### PR DESCRIPTION
Part 2 of Search CRUD topics update.  This one includes Rename and Delete a search view.

Note for reviewers: The JavaScript "Rename a Search View" sample does not work 100% as intended as it returns `undefined` instead of the new Search View name.  I could use some help fixing this since my JS is not nearly as strong as my Python.