### PR TITLE
updated slack link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -130,7 +130,7 @@ const config = {
           },
           {
             className: 'navbar__item--external',
-            href: 'https://join.slack.com/t/macrometa/shared_invite/zt-1j4f06xwm-5Y~yGQz8CVImOowdc80s1A',
+            href: 'https://macrometa.slack.com/join/shared_invite/zt-1v7jkj1tf-C6usbL12TBUUGlikJD9png#/shared-invite/email',
             label: 'Slack',
             position: 'right',
           },


### PR DESCRIPTION
As requested per Slack https://macrometa-team.slack.com/archives/C036H7PMUTD/p1682970019789949

we are updating the URL for the community Slack server