### PR TITLE
Update link to Search tutorial

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -149,4 +149,4 @@ IN addresses
 You have a fully-functional API for your application. [We made a front-end for you to take your new back-end for a spin](https://github.com/Macrometacorp/tutorial-addressbook-streams).
 
 
-## Next Up: [Add Search to your app](https://www.macrometa.com/docs/search/getting-started)
+## Next Up: [Add Search to your app](https://www.macrometa.com/docs/search/getting-started-search)


### PR DESCRIPTION
Link at the bottom of the page was broken - edited to fix it. 