### PR TITLE
17.17 - Add Connection Metrics to release notes

### DIFF
--- a/docs/release-notes/release-notes-0-17-17.md
+++ b/docs/release-notes/release-notes-0-17-17.md
@@ -91,7 +91,18 @@ Description of update.
 
 ### Connection Metrics API Endpoint
 
-You can now access the `GET /_api/connections/metrics` endpoint to retrieve metrics for your connections.
+You can now access the `GET /_api/connections/metrics` endpoint to retrieve metrics for your connections. The response includes metrics for:
+
+- Ingested documents
+- Exported documents
+- Ingested bytes
+- Exported bytes
+- Ingest lag
+- Export lag
+- Ingest errors
+- Export errors
+- Successful workflows
+- Failed workflows
 
 ### Miscellaneous Changes
 

--- a/docs/release-notes/release-notes-0-17-17.md
+++ b/docs/release-notes/release-notes-0-17-17.md
@@ -89,6 +89,9 @@ The stream stats API endpoint `/_fabric/{fabric}/_api/streams/{stream}/stats` no
 
 Description of update.
 
+### Connection Metrics API Endpoint
+
+You can now access the `GET /_api/connections/metrics` endpoint to retrieve metrics for your connections.
 
 ### Miscellaneous Changes
 


### PR DESCRIPTION
This PR adds an entry for the Connection Metrics API endpoint to the release notes.

Reviewers, is there anything else that we should mention to the user? I would like to tell them what the metrics include, but that was not clear to me from the API Reference sample response.