### PR TITLE
Rename VWRS domain fields

### DIFF
--- a/docs/photoniq/vwrs/configure-domain.md
+++ b/docs/photoniq/vwrs/configure-domain.md
@@ -25,7 +25,7 @@ The following required fields define a domain (waiting room):
     - The metric service counts the number of requests to the origin server per second (RPS).
     - **Rate Calculation Example**: If the maximum number of requests allowed is 20 and 13 POST requests are detected, then 7 more requests are released from the waiting room.
   
-- **period**: Must be set if the `access_type` is `users_per_period`.
+- **rate_period**: Must be set if the `access_type` is `users_per_period`.
   - Defines the time (in seconds) for rate calculation.
   - Must be a number greater than zero.
 
@@ -38,10 +38,10 @@ The following required fields define a domain (waiting room):
 The following optional fields define the behavior of the waiting room:
 
 - **queue_type**: Defines how requests should be removed from the waiting room. The three possible queue types are `fifo`, `random`, and `lottery`. If this is not set, then the default queue is `fifo`.
-- **queue_enablement**: You can configure the waiting room to be enabled dynamically. When set to `auto`, the waiting room is enabled after reaching the defined `rate_limit` for a specific `metric_interval`. If set to `manual`, then the waiting room is always enabled.
+- **queue_mode**: You can configure the waiting room to be enabled dynamically. When set to `auto`, the waiting room is enabled after reaching the defined `rate_limit` for a specific `metric_interval`. If set to `manual`, then the waiting room is always enabled.
 - **origin_key**: Every domain is associated with an origin that was created with the Create Origin REST API, POST `/api/vwr/v1/origins/{origin_id}`.
 - **metric_interval**: The time (in seconds) to enable and disable the waiting room. It represents how long the traffic must be at or above the rate limit before being directed to the waiting room.
-- **access_duration**: The time (in seconds) that users can access the origin after being granted access. After this period, users are forwarded to the waiting room again.
-- **status_interval**: Defined in seconds, this interval determines how often the waiting room HTML page is updated with information like the request's position, estimated waiting time, and the maximum number of requests in the waiting room.
+- **max_origin_usage_time**: The time (in seconds) that users can access the origin after being granted access. After this period, users are forwarded to the waiting room again.
+- **waiting_room_interval**: Defined in seconds, this interval determines how often the waiting room HTML page is updated with information like the request's position, estimated waiting time, and the maximum number of requests in the waiting room.
 - **waiting_room_path**: The cloud origin (such as NetStorage) path for a domain that stores the HTML for the waiting room. The path should be a fully qualified path like `/{upload-directory-id}/path`.
-- **priority**: An array of priorities, where the highest priority corresponds to the lowest number.
+- **request_priority**: An array of priorities, where the highest priority corresponds to the lowest number.

--- a/docs/photoniq/vwrs/configure-vwrs-edgeworker.md
+++ b/docs/photoniq/vwrs/configure-vwrs-edgeworker.md
@@ -42,8 +42,8 @@ The following configuration options are optional:
 
 - **isFailOpen**: When set to `true` (fail open) and an error occurs, the request is forwarded to the origin. An error message is displayed when set to `false` (fail close) and an error occurs. (default: `true`).
 - **originAccessMode**: This option determines how long access is granted to the origin server (default: `MOVING`):
-  - **FIXED**: The access time, defined for each domain (`access_duration`), remains fixed. Once a user is granted access to the origin, they can only access it for the duration specified in the `access_duration` field.
-  - **MOVING:** The access time, defined for each domain, increases by the number of seconds specified in the `access_duration` field. Each time this domain is accessed, the access time is extended accordingly. This behaves similarly to an abandonment timeout, where the session is abandoned if the request has been idle for the `access_duration` time.
+  - **FIXED**: The access time, defined for each domain (`max_origin_usage_time`), remains fixed. Once a user is granted access to the origin, they can only access it for the duration specified in the `max_origin_usage_time` field.
+  - **MOVING:** The access time, defined for each domain, increases by the number of seconds specified in the `max_origin_usage_time` field. Each time this domain is accessed, the access time is extended accordingly. This behaves similarly to an abandonment timeout, where the session is abandoned if the request has been idle for the `max_origin_usage_time` time.
 - **statusConfigLimits**: This defines the waiting room information that is returned by the status call. Use the following three values to define what the status page returns:
   - **avgWaitingTime**: If set to `true`, then the average waiting time is returned by the status call. (default: `true`)
   - **qDepth**: If set to `true`, then the waiting room queue size is returned. (default: `true`)

--- a/docs/photoniq/vwrs/configure-waiting-rooms.md
+++ b/docs/photoniq/vwrs/configure-waiting-rooms.md
@@ -15,11 +15,11 @@ This page explains what can be configured in each waiting room using API endpoin
 
 - **Waiting Room HTML:** UI that is shown to users in the waiting room. (`waiting_room_path` property)
 - **Waiting Room Position and Time (in HTML):** Include any of the position or time in the waiting room UI. (Configured in the [Akamai EdgeWorker](configure-vwrs-edgeworker.md).)
-- **Waiting Room HTMl Refresh Interval:** How often waiting room UI should be refreshed in the user's browser. (`status_interval` property)
+- **Waiting Room HTMl Refresh Interval:** How often waiting room UI should be refreshed in the user's browser. (`waiting_room_interval` property)
 
 ## Exiting the Waiting Room
 
-- **Access Duration:** The amount of time that users can access the origin after being granted access. (`access_duration` property)
+- **Max Origin Usage Time:** The amount of time that users can access the origin after being granted access. (`max_origin_usage_time` property)
 - **Access Type:** Choose one of the following options. (Configured in the [Akamai EdgeWorker](configure-vwrs-edgeworker.md).)
-  - Following the access duration period (set in the `access_duration` property), the user is redirected to the waiting room.
-  - The user is redirected to the waiting room if there is no activity for the duration of the access duration period (set in the `access_duration` property).
+  - Following the access duration period (set in the `max_origin_usage_time` property), the user is redirected to the waiting room.
+  - The user is redirected to the waiting room if there is no activity for the duration of the access duration period (set in the `max_origin_usage_time` property).

--- a/static/openapi/vwrs-spec.json
+++ b/static/openapi/vwrs-spec.json
@@ -309,7 +309,7 @@
             "description": "The type of queue (fifo, random, lottery).",
             "default": "fifo"
           },
-          "queue_enablement": {
+          "queue_mode": {
             "type": "string",
             "description": "If set to auto, then the decision to enable the waiting room is determined by the traffic rate exceeding the rate limit set by rate_limit. If set to manual, then the decision to direct traffic to the waiting room is performed all the time.",
             "default": "auto"
@@ -335,25 +335,25 @@
             "minimum": 1,
             "default": 100
           },
-          "period": {
+          "rate_period": {
             "type": "number",
             "description": "The period for the _users_per_period_ rate (in seconds).",
             "minimum": 1,
             "default": 1
           },
-          "access_duration": {
+          "max_origin_usage_time": {
             "type": "number",
-            "description": "The amount of time that users can access the origin (in seconds). Once a user has been granted access, the access_duration determines how long that user can access the origin before they are forwarded to the waiting room after coming to the EdgeWorker again.",
+            "description": "The amount of time that users can access the origin (in seconds). Once a user has been granted access, the max_origin_usage_time determines how long that user can access the origin before they are forwarded to the waiting room after coming to the EdgeWorker again.",
             "default": 60,
             "minimum": 1
           },
-          "status_interval": {
+          "waiting_room_interval": {
             "type": "number",
             "description": "The time interval when the UI reloads itself to get the waiting room status.",
             "default": 10,
             "minimum": 1
           },
-          "priority": {
+          "request_priority": {
             "type": "array",
             "maxItems": 10,
             "description": "The domain has a range of priorities, where the highest priority corresponds to the lowest number.",

--- a/static/swagger/vwrs-spec.json
+++ b/static/swagger/vwrs-spec.json
@@ -304,7 +304,7 @@
             "description": "The type of queue (fifo, random, lottery).",
             "default": "fifo"
           },
-          "queue_enablement": {
+          "queue_mode": {
             "type": "string",
             "description": "If set to auto, then the decision to enable the waiting room is determined by the traffic rate exceeding the rate limit set by rate_limit. If set to manual, then the decision to direct traffic to the waiting room is performed all the time.",
             "default": "auto"
@@ -330,25 +330,25 @@
             "minimum": 1,
             "default": 100
           },
-          "period": {
+          "rate_period": {
             "type": "number",
             "description": "The period for the _users_per_period_ rate (in seconds).",
             "minimum": 1,
             "default": 1
           },
-          "access_duration": {
+          "max_origin_usage_time": {
             "type": "number",
-            "description": "The amount of time that users can access the origin (in seconds). Once a user has been granted access, the access_duration determines how long that user can access the origin before they are forwarded to the waiting room after coming to the EdgeWorker again.",
+            "description": "The amount of time that users can access the origin (in seconds). Once a user has been granted access, the max_origin_usage_time determines how long that user can access the origin before they are forwarded to the waiting room after coming to the EdgeWorker again.",
             "default": 60,
             "minimum": 1
           },
-          "status_interval": {
+          "waiting_room_interval": {
             "type": "number",
             "description": "The time interval when the UI reloads itself to get the waiting room status.",
             "default": 10,
             "minimum": 1
           },
-          "priority": {
+          "request_priority": {
             "type": "array",
             "maxItems": 10,
             "description": "The domain has a range of priorities, where the highest priority corresponds to the lowest number.",


### PR DESCRIPTION
new name : old name

'rate_period': 'period',
'queue_mode': 'queue_enablement',
'request_priority': 'priority',
'waiting_room_interval': 'status_interval',
'max_origin_usage_time': 'access_duration'

Jira: https://macrometa.atlassian.net/browse/VWROOM-266
Parent Jira: https://macrometa.atlassian.net/browse/VWROOM-264

Will potentially be merged after the code and front-end changes are in place.